### PR TITLE
chore: docker-compose cleanup and PostgreSQL migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ Thumbs.db
 # Database
 *.sqlite3
 db/postgres/
+
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@
 services:
   backend:
     build: ./backend
-    volumes:
-    - ./backend/db.sqlite3:/code/db.sqlite3
     container_name: pong_backend
+    volumes:
+      - ./backend:/app
     environment:
       - DJANGO_SETTINGS_MODULE=django_server.settings
       - DEBUG=True
@@ -28,7 +28,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    container_name: pong_frontend_dev
+    container_name: pong_frontend
     ports:
       - "5173:5173"
     volumes:
@@ -40,7 +40,7 @@ services:
       - VITE_BACKEND_URL=http://backend:3000
 
   db:
-    container_name: transcendence_db
+    container_name: pong_db
     image: postgres:17-alpine
     environment:
       - POSTGRES_DB=transcendence
@@ -54,6 +54,7 @@ services:
       - "5432:5432"
 
   redis:
+    container_name: pong_redis
     image: redis:7-alpine
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Cleaned up docker-compose.yml to remove all traces of SQLite and standardize the setup around PostgreSQL.
Changes

Removed SQLite volume mount (./backend/db.sqlite3:/code/db.sqlite3) - project now uses PostgreSQL exclusively
Added ./backend:/app volume mount to backend service - files created inside the container sync to the local project automatically, no need for docker cp
Renamed containers to a consistent pong_ prefix:

pong_frontend_dev → pong_frontend
transcendence_db → pong_db
auto-generated trans_2802-redis-1 → pong_redis


Added __pycache__/ and *.pyc to .gitignore - Python bytecode files should never be committed