### PR TITLE
feat(chat): block/unblock UI with textarea lockout + auto migrations 

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,4 +20,4 @@ RUN mkdir -p /app/logs
 # Expose port
 EXPOSE 3000
 
-CMD ["daphne", "-b", "0.0.0.0", "-p", "3000", "django_server.asgi:application"]
+CMD ["sh", "-c", "python manage.py migrate && daphne -b 0.0.0.0 -p 3000 django_server.asgi:application"]

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -229,7 +229,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		# Deliver the updated online users list to this consumer's client.
 		await self.send(text_data=json.dumps({
 			"type": "online_users",
-			"users": event["users"]
+			"users": event["users"],
+			"blocked_me_ids": event.get("blocked_me_ids", [])
 		}))
 
 	async def broadcast_online_users(self):
@@ -250,7 +251,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			for channel_name in channels:
 				await self.channel_layer.send(channel_name, {
 					"type": "online.users",
-					"users": users
+					"users": users,
+					"blocked_me_ids": list(blocked_me)
 				})
 
 	# ─── Database helpers ─────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,7 +68,10 @@
 					<textarea id="chatInput" rows="2" placeholder="Type a message..."
 						class="w-full px-3 py-2 bg-gray-800 text-white rounded resize-none 
 									focus:outline-none focus:ring-2 focus:ring-pink-500"></textarea>
-						<div id="charCounter" class="text-xs text-right mt-1 text-gray-400">0 / 300</div>
+						<div class="flex items-center justify-between mt-1">
+							<div id="blockNotice" style="display:none;" class="text-xs text-gray-400"></div>
+							<div id="charCounter" class="text-xs text-gray-400 ml-auto">0 / 300</div>
+						</div>
 						<button id="sendChatBtn"
 						class="mt-2 w-full py-2 bg-pink-500 hover:bg-pink-400 
 									rounded font-semibold transition-colors">

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -2,7 +2,8 @@
 // The WebSocket connection itself lives in chat.js —
 // this file reacts to events dispatched by chat.js and manages the DOM.
 
-import { onlineUsers, sendChatMessage, initTyping, verifiedUserId, fetchDMHistory, markRead, closeConversation, openConversation, notifyBlocked } from './chat.js';
+import { onlineUsers, blockedMeIds, sendChatMessage, initTyping, verifiedUserId, fetchDMHistory, markRead, closeConversation, openConversation, notifyBlocked } from './chat.js';
+import { fetchWithRefreshAuth } from '../users_friends/usermanagement.js';
 
 export function initChatUI() {
 
@@ -16,6 +17,7 @@ export function initChatUI() {
 	const channelTabs = document.getElementById("channelTabs");
 	const chatMessages = document.getElementById("chatMessages");
 	const channelTitle = document.getElementById("channelTitle");
+	const blockNotice = document.getElementById("blockNotice");
 
 	// ── State ─────────────────────────────────────────────────────────────────
 	// activeChannel is either "global" or a user ID for DMs
@@ -25,6 +27,30 @@ export function initChatUI() {
 	const messageHistory = { global: [] };
 
 	// ── Channel management ────────────────────────────────────────────────────
+
+	function updateDMInputState(channelId) {
+		if (channelId === "global") {
+			chatInput.disabled = false;
+			sendChatBtn.disabled = false;
+			blockNotice.style.display = "none";
+			blockNotice.textContent = "";
+			return;
+		}
+		const blockedByMe = onlineUsers[channelId]?.blocked_by_me;
+		const blockedMe = blockedMeIds.has(channelId);
+		if (blockedByMe || blockedMe) {
+			chatInput.disabled = true;
+			sendChatBtn.disabled = true;
+			chatInput.value = "";
+			blockNotice.textContent = blockedByMe ? "You have blocked this user." : "You have been blocked.";
+			blockNotice.style.display = "block";
+		} else {
+			chatInput.disabled = false;
+			sendChatBtn.disabled = false;
+			blockNotice.style.display = "none";
+			blockNotice.textContent = "";
+		}
+	}
 
 	function switchChannel(channelId) {
 		activeChannel = channelId;
@@ -53,6 +79,7 @@ export function initChatUI() {
 		}
 
 		renderMessages(channelId);
+		updateDMInputState(channelId);
 		document.getElementById("chatInput").focus();
 	}
 
@@ -197,6 +224,7 @@ export function initChatUI() {
 			statusDot.className = "w-2 h-2 rounded-full bg-[#00FF00] flex-shrink-0";
 
 			const nameSpan = document.createElement("span");
+			nameSpan.className = "user-name";
 			nameSpan.textContent = name;
 
 			div.appendChild(statusDot);
@@ -209,9 +237,8 @@ export function initChatUI() {
 				unblockBtn.className = "ml-auto text-xs text-pink-400 hover:text-pink-200";
 				unblockBtn.addEventListener("click", (e) => {
 					e.stopPropagation();
-					fetch('/api/friends/unblock', {
+					fetchWithRefreshAuth('/api/friends/unblock', {
 						method: 'DELETE',
-						credentials: 'include',
 						headers: { 'Content-Type': 'application/json' },
 						body: JSON.stringify({ user_id: id })
 					}).then(() => notifyBlocked());
@@ -232,7 +259,10 @@ export function initChatUI() {
 	// ── Event listeners ───────────────────────────────────────────────────────
 
 	// chat.js dispatches this whenever the online users list changes
-	window.addEventListener("onlineUsersUpdated", renderOnlineUsers);
+	window.addEventListener("onlineUsersUpdated", () => {
+		renderOnlineUsers();
+		updateDMInputState(activeChannel);
+	});
 
 	// chat.js dispatches this whenever a message arrives
 	window.addEventListener("chatMessageReceived", (e) => {
@@ -340,14 +370,12 @@ export function initChatUI() {
 			openDMChannel(chatMenuUser.id, chatMenuUser.name || chatMenuUser.id);
 		} else if (action === "block") {
 			const targetId = chatMenuUser.id;
-			fetch('/api/friends/block', {
+			fetchWithRefreshAuth('/api/friends/block', {
 				method: 'POST',
-				credentials: 'include',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ user_id: targetId })
 			}).then(r => r.json()).then(data => {
 				if (data.success) {
-					closeDMChannel(targetId);
 					notifyBlocked();
 				} else {
 					console.warn("Block failed:", data.error);

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -15,6 +15,8 @@ let verifiedUserName = null;
 // Exported so other modules (e.g. main.js) can read the current online users
 // Shape: { user_id: username } e.g. { "42": "tamar", "7": "rik" }
 export let onlineUsers = {};
+// Set of user IDs who have blocked the current user
+export let blockedMeIds = new Set();
 
 export function initChat() {
 	
@@ -94,6 +96,7 @@ export function initChat() {
 			case "online_users":
 				console.log("Received online_users message:", data.users);
 				onlineUsers = data.users;
+				blockedMeIds = new Set(data.blocked_me_ids || []);
 				window.dispatchEvent(new CustomEvent("onlineUsersUpdated"));
 				break;
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -169,10 +169,12 @@
   overflow: hidden;
 }
 
-.user-item span:last-child {
+.user-item .user-name {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
 }
 
 .user-item:hover {


### PR DESCRIPTION
Block/unblock UX:                        
- Disable textarea and show contextual notice ("You have blocked this user." / "You have been blocked.") when either side has blocked the other; notice shares a line with the char counter so the input area never resizes 
- Include blocked_me_ids in every online_users broadcast so the blocked party knows they've been blocked even though the blocker is hidden from their user list            
- React to live block/unblock events while the DM tab is open, so the notice appears/disappears instantly without a tab switch             
- Use fetchWithRefreshAuth for block/unblock calls to survive the 2-minute JWT expiry                    
- Keep DM tab open after blocking so the notice can show                   
- Fix long username truncation in the online users sidebar by switching from span:last-child to a .user-name class                                    
  
Infrastructure:                          
- Run python manage.py migrate automatically on backend container startup so switching branches never causes 500 errors from an out-of-sync database