### PR TITLE
now navigating away from a live chess game ends in a forfeit

### DIFF
--- a/frontend/src/chess/chess-online.js
+++ b/frontend/src/chess/chess-online.js
@@ -3,6 +3,15 @@ import { renderBoard } from './chess.js'
 import { showChessResultModal } from './chess-modal.js'
 import { navigate } from '../routes/route_helpers.js'
 
+let _chessWs = null;
+
+export function closeChessConnection(){
+	if (_chessWs && (_chessWs.readyState === WebSocket.OPEN || _chessWs.readyState === WebSocket.CONNECTING)){
+		_chessWs.close();
+	}
+	_chessWs = null;
+}
+
 function subtitleFromResult(result) {
 	if (!result) return '';
 	const r = String(result).toLowerCase();
@@ -79,6 +88,7 @@ export async function initOnlineChessGame(gameId = null){
 
 	const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
 	const ws = new WebSocket(`${proto}//${location.host}/ws/chess/${gameId}`);
+	_chessWs = ws;
 
 	ws.onmessage = (event) => {
 		const data = JSON.parse(event.data);
@@ -123,9 +133,16 @@ export async function initOnlineChessGame(gameId = null){
 		}
 	};
 
+	const browserExitHandler = () => closeChessConnection();
+	window.addEventListener('beforeunload', browserExitHandler);
+	window.addEventListener('pagehide', browserExitHandler);
+
 	ws.onclose = () => {
 		gameActive = false;
 		myTurn     = false;
+		_chessWs = null;
+		window.removeEventListener('beforeunload', browserExitHandler);
+   		window.removeEventListener('pagehide',     browserExitHandler);
 	};
 
 	boardEl.addEventListener('click', (e) => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,6 +5,7 @@ import { initChatUI } from './chat/chat-ui.js';
 import { closeGameConnection } from './pong/game/game.js';
 import { handleRoute } from './routes/route_helpers.js';
 import { isGameActive } from './pong/game/game.js'
+import { closeChessConnection } from "./chess/chess-online.js";
 
 // --- Game Variables ---
 let ws = null;
@@ -21,6 +22,7 @@ window.addEventListener('popstate', () => {
 		closeGameConnection();
 		sessionStorage.removeItem('activeGameId');
 	}
+	closeChessConnection();
 	handleRoute(window.location.pathname);
 });
 

--- a/frontend/src/routes/route_helpers.js
+++ b/frontend/src/routes/route_helpers.js
@@ -2,8 +2,12 @@
 import { routes } from "../main.js";
 import { updatePageTranslations } from '../i18n/index.js';
 import { handleTournamentRoute } from './routes.js';
+import { closeChessConnection } from "../chess/chess-online.js";
 
 export function navigate(path) {
+    if (window.location.pathname === '/chess-online' && path !== '/chess-online'){
+        closeChessConnection();
+    }
     window.history.pushState({}, path, window.location.origin + path);
     handleRoute(path);
 }


### PR DESCRIPTION
Fixed a bug where only refresh terminating a game. Now, navigating anywhere froma. live chess game or closing the window will result in a loss.
