### PR TITLE
fix(chat/chess): enforce invite availability and clean up stale    invite cards

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -244,7 +244,18 @@ class ChatConsumer(AsyncWebsocketConsumer):
 						})
 
 		elif msg_type == "user_blocked":
-			# Re-broadcast online users so blocked users disappear from each other's list immediately.
+			target = data.get("target")
+			if target:
+				invite_ids = await self.get_invite_ids_with(target)
+				for gid in invite_ids:
+					await self.channel_layer.group_send(
+						f'user_{self.user_id}',
+						{'type': 'game.invite.blocked', 'game_id': gid}
+					)
+					await self.channel_layer.group_send(
+						f'user_{target}',
+						{'type': 'game.invite.expired', 'game_id': gid}
+					)
 			await self.broadcast_online_users()
 
 		elif msg_type in ["typing", "stop_typing"]:
@@ -294,6 +305,14 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		await self.send(text_data=json.dumps({
 			"type": "game_invite_accepted",
 			"game_id": event["game_id"],
+		}))
+
+	async def game_invite_blocked(self, event):
+		game_id = event["game_id"]
+		await self.delete_invite(game_id)
+		await self.send(text_data=json.dumps({
+			"type": "game_invite_blocked",
+			"game_id": game_id,
 		}))
 
 	async def game_invite_expired(self, event):
@@ -463,6 +482,22 @@ class ChatConsumer(AsyncWebsocketConsumer):
 				conversation=conversation,
 				user_id=recipient_id
 			).update(unread_count=F('unread_count') + 1, is_closed=False)
+
+	@database_sync_to_async
+	def get_invite_ids_with(self, other_id):
+		from chat.models import GameInvite, ConversationParticipant
+		my_conv_ids = ConversationParticipant.objects.filter(
+			user_id=self.user_id
+		).values_list('conversation_id', flat=True)
+		shared_conv_id = ConversationParticipant.objects.filter(
+			conversation_id__in=my_conv_ids,
+			user_id=other_id
+		).values_list('conversation_id', flat=True).first()
+		if not shared_conv_id:
+			return []
+		return list(GameInvite.objects.filter(
+			conversation_id=shared_conv_id
+		).values_list('game_id', flat=True))
 
 	@database_sync_to_async
 	def delete_invite(self, game_id):

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -43,9 +43,11 @@ class ChessConsumer(AsyncWebsocketConsumer):
 			'color': self.color
 		}))
 
+		# Mark this player unavailable for invites as soon as they enter any chess session.
+		IN_GAME_USERS.add(str(self.scope['user'].id))
+
 		if self.game.can_start():
 			self.game.start()
-			# Mark both players as in-game so chat can reject invites to them
 			player_ids = [str(p.id) for p in self.game.players.values() if p]
 			for pid in player_ids:
 				IN_GAME_USERS.add(pid)
@@ -68,6 +70,8 @@ class ChessConsumer(AsyncWebsocketConsumer):
 				'white': getattr(self.game.players['white'], 'username', 'Player 1'),
 				'black': getattr(self.game.players['black'], 'username', 'Player 2'),
 			})
+		else:
+			await self.channel_layer.group_send('global_chat', {'type': 'trigger.online.users.broadcast'})
 	
 
 	async def disconnect(self, _close_code):
@@ -94,10 +98,12 @@ class ChessConsumer(AsyncWebsocketConsumer):
 				})
 
 			elif self.game.status == 'waiting' and self.game.invitee_id is not None:
-				await self.channel_layer.group_send(
-					f'user_{self.game.invitee_id}',
-					{'type': 'game.invite.expired', 'game_id': self.game_id}
-				)
+				invitor_id = str(self.game.players[self.color].id)
+				for uid in [self.game.invitee_id, invitor_id]:
+					await self.channel_layer.group_send(
+						f'user_{uid}',
+						{'type': 'game.invite.expired', 'game_id': self.game_id}
+					)
 
 			# Remove both players from in-game tracking
 			for player in self.game.players.values():

--- a/backend/chessgame/views.py
+++ b/backend/chessgame/views.py
@@ -52,7 +52,7 @@ def join_chess(request):
 							game.players['white'] = user
 						else:
 							game.players['black'] = user
-					
+
 					return JsonResponse({'gameId': game.id})
 
 		game = ChessSession()

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -427,7 +427,7 @@ export function initChatUI() {
 				body: JSON.stringify({ user_id: targetId })
 			}).then(r => r.json()).then(data => {
 				if (data.success) {
-					notifyBlocked();
+					notifyBlocked(targetId);
 				} else {
 					console.warn("Block failed:", data.error);
 				}
@@ -484,7 +484,7 @@ export function initChatUI() {
 			const gameId = data.gameId;
 			console.log('[invite] gameId from response:', gameId);
 			sendGameInvite(targetId, "chess", gameId);
-			openDMChannel(targetId, targetName);
+			openDMChannel(targetId, targetName, true, false);
 			addMessage(targetId, {
 				senderId: verifiedUserId,
 				senderName: null,
@@ -539,6 +539,13 @@ export function initChatUI() {
 
 	window.addEventListener("gameInviteAccepted", (e) => removeInviteFromHistory(e.detail.gameId));
 	window.addEventListener("gameInviteExpired", (e) => removeInviteFromHistory(e.detail.gameId));
+	window.addEventListener("gameInviteBlocked", (e) => {
+		removeInviteFromHistory(e.detail.gameId);
+		if (pendingInvite) {
+			pendingInvite = false;
+			window.history.back();
+		}
+	});
 
 	// ── Send message ──────────────────────────────────────────────────────────
 	

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -133,6 +133,12 @@ export function initChat() {
 				}));
 				break;
 
+			case "game_invite_blocked":
+				window.dispatchEvent(new CustomEvent("gameInviteBlocked", {
+					detail: { gameId: data.game_id }
+				}));
+				break;
+
 			case "game_invite_rejected":
 				window.dispatchEvent(new CustomEvent("gameInviteRejected", {
 					detail: { reason: data.reason }
@@ -286,9 +292,9 @@ export function closeConversation(targetId) {
 	}));
 }
 
-export function notifyBlocked() {
+export function notifyBlocked(targetId = null) {
 	if (!chatSocket || chatSocket.readyState !== WebSocket.OPEN) return;
-	chatSocket.send(JSON.stringify({ type: "user_blocked" }));
+	chatSocket.send(JSON.stringify({ type: "user_blocked", target: targetId }));
 }
 
 export function sendGameInvite(targetId, gameType, gameId) {


### PR DESCRIPTION
- Players in a waiting room are now immediately marked unavailable for invites (previously only marked when the game went active), so no one can invite a player who is already waiting for an opponent
- Blocking someone with a pending invite now cleans up both sides: the blocker's card is removed and they are navigated back from the waiting screen; the blockee's Accept button is removed                            
- Navigating away from the chess waiting screen now removes the invite card from both the invitor's and invitee's DMs                            
- Fixed: "You invited X" card was disappearing immediately after sending because an async DB fetch was overwriting the locally-added card. Fixed by not fetching history during the invite flow