### PR TITLE
Online pong

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -286,8 +286,8 @@ class GameConsumer(AsyncWebsocketConsumer):
                     self.game.state['score']['p2'] = 0
                 result_data = await database_sync_to_async(match_ends)(
                     self.game,
-                    self.game.players['left'],
-                    self.game.players['right'],
+                    players_before['left'],
+                    players_before['right'],
                 )
                 new_achievements = result_data.get('new_achievements', {})
 

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -181,8 +181,7 @@ class GameConsumer(AsyncWebsocketConsumer):
         logger.debug(f"Connecting to game: {self.game_id} with channel: {self.channel_name} and player {self.scope['user']}")
         logger.debug(f"Current players: {self.game.get_players()}")
 
-        players = self.game.get_players()
-        if players['left'] == self.scope['user'] or players['right'] == self.scope['user']:
+        if self.scope['user'] in self.game.clients:
             logger.warning(f"Duplicate connection attempt by {self.scope['user']}")
             self.game.status = 'ready'
             # Update tournament game status in database

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -248,8 +248,9 @@ class GameConsumer(AsyncWebsocketConsumer):
             # Start game loop
             asyncio.create_task(self.game_loop())
         else:
-            # Start timeout checker if this is a tournament game in waiting state
-            asyncio.create_task(self.check_join_timeout())
+            if self.game.isTournamentGame:
+                # Start timeout checker if this is a tournament game in waiting state
+                asyncio.create_task(self.check_join_timeout())
 
     async def disconnect(self, close_code):
         logger.debug(f"Disconnecting from game: {self.game_id} with channel: {self.channel_name} and player {self.scope['user']}")
@@ -414,6 +415,8 @@ class GameConsumer(AsyncWebsocketConsumer):
         }))
     
     async def check_join_timeout(self):
+        if not self.game or not sef.game.isTournamentGame:
+            return
         """Check for join timeout and handle results if expired"""
         while self.game and self.game.status == 'waiting' and not self.game.timeout_handled:
             # Send remaining time update every second

--- a/backend/game/models.py
+++ b/backend/game/models.py
@@ -66,6 +66,16 @@ class GameSession:
     
     def add_player(self, name, id, role=None):
         """Add a player or spectator to the game"""
+        # If matchmaking pre-assigned this user to a side, reconnect them there.
+        if self.players['left'] == name:
+            self.players_ids['left'] = id
+            self.clients.add(name)
+            return 'left'
+        if self.players['right'] == name:
+            self.players_ids['right'] = id
+            self.clients.add(name)
+            return 'right'
+
         if not self.players['left']:
             self.players['left'] = name
             self.players_ids['left'] = id

--- a/backend/game/urls.py
+++ b/backend/game/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path('game/create', views.create_game, name='create_game'),
     path('game/record-local-match/', views.record_local_match, name='record_local_match'),
     path('game/<str:game_id>', views.get_game, name='get_game'),
+    path('game/join', views.join_pong, name='join_pong'),
     path('games', views.list_games, name='list_games'),
     path('leaderboard', views.get_leaderboard, name='get_leaderboard'),
     path('match-history', views.match_history, name='match_history'),

--- a/backend/game/urls.py
+++ b/backend/game/urls.py
@@ -4,8 +4,8 @@ from . import views
 urlpatterns = [
     path('game/create', views.create_game, name='create_game'),
     path('game/record-local-match/', views.record_local_match, name='record_local_match'),
-    path('game/<str:game_id>', views.get_game, name='get_game'),
     path('game/join', views.join_pong, name='join_pong'),
+    path('game/<str:game_id>', views.get_game, name='get_game'),
     path('games', views.list_games, name='list_games'),
     path('leaderboard', views.get_leaderboard, name='get_leaderboard'),
     path('match-history', views.match_history, name='match_history'),

--- a/backend/game/views.py
+++ b/backend/game/views.py
@@ -8,6 +8,7 @@ import jwt
 from .models import GameSession, Player, Match, PlayerAchievement
 from .services import get_match_history
 import logging
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,35 @@ def get_authenticated_user(request):
         return user, None
     except (jwt.ExpiredSignatureError, jwt.DecodeError, User.DoesNotExist):
         return None, JsonResponse({'error': 'Invalid or expired token'}, status=401)
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def join_pong(request):
+    user,error = get_authenticated_user(request)
+    if error:
+        return error
+    with GameSession._lock:
+        for game in GameSession._games.values():
+            if game.status == 'waiting' and not game.isTournamentGame:
+                left_id = getattr(game.players['left'], 'id', None)
+                right_id = getattr(game.players['right'], 'id', None)
+                #if exactly one slot is filled
+                if (left_id is None) != (right_id is None):
+                    if (user.id not in (left_id, right_id)):
+                        if game.players['left'] is None:
+                            game.players['left'] = user
+                        else:
+                            game.players['right'] = user
+                    return JsonResponse({'gameId': game.id})
+    
+    #if no game with empty slot exists, create a new one and allocate a random left or right position to the player
+    game = GameSession.create_game()
+    game.isTournamentGame = False
+    side = random.choice(['left', 'right'])
+    game.players[side] = user
+    return JsonResponse({'gameId': game.id})    
+
+
 
 # Cross-Site Request Forgery token is exempted because
 # Auth is handled via JWT in cookies, not Django's session system

--- a/frontend/src/home/home.js
+++ b/frontend/src/home/home.js
@@ -1,5 +1,6 @@
 import { navigate } from "../routes/route_helpers.js";
 import { setChessOnlineIntended } from "../routes/routes.js";
+import { joinMatchmaking } from "../pong/game/game.js";
 
 export function initHome() {
     const username = localStorage.getItem('username');
@@ -71,7 +72,7 @@ export function initHome() {
     document.getElementById('online-close-btn')?.addEventListener('click', () => closeOnlinePanel());
     document.getElementById('online-backdrop')?.addEventListener('click', () => closeOnlinePanel());
 
-    document.getElementById('play-ranked-btn')?.addEventListener('click', () => navigate('/online'));
+    document.getElementById('play-ranked-btn')?.addEventListener('click', () => joinMatchmaking());
     document.getElementById('play-tournament-btn')?.addEventListener('click', () => navigate('/tournament'));
 
     document.getElementById('localBtn')?.addEventListener('click', () => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -27,6 +27,14 @@ window.addEventListener('popstate', () => {
 	handleRoute(window.location.pathname);
 });
 
+window.addEventListener('beforeunload', () => {
+	// Trigger disconnect when refreshing, closing tab/window, or hard navigation
+	if (isGameActive){
+		closeGameConnection();
+		sessionStorage.removeItem('activeGameId');
+		sessionStorage.removeItem('activeTournamentId');
+	}	
+})
 // Auto-reconnect to game if page was refreshed
 /*
 window.addEventListener('load', async () => {

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -347,6 +347,7 @@ export function joinOnlineGame(gameId, IsTournament) {
       sessionStorage.removeItem('activeTournamentId');
 
     }
+    canvas.remove();
     if (IsTournament) {
       navigate(`/tournament/${window.currentTournamentId}`);
     } else {

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -29,6 +29,43 @@ function showAchievements(achievements) {
     setTimeout(() => overlay.remove(), 6000);
 }
 
+function showPongResultModal({ winnerId, winnerName, currentUserId }) {
+  const didWin = winnerId != null && Number(winnerId) === currentUserId;
+  const title = didWin ? 'You Won!' : 'You Lost';
+  const accent = didWin ? 'border-green-400 text-green-300' : 'border-red-400 text-red-300';
+  const glow = didWin
+    ? 'shadow-[0_0_30px_rgba(74,222,128,0.35)]'
+    : 'shadow-[0_0_30px_rgba(248,113,113,0.35)]';
+  const overlay = document.createElement('div');
+  overlay.id = 'pongResultModal';
+  overlay.className = 'fixed inset-0 z-[9999] flex items-center justify-center bg-black/70 backdrop-blur-sm';
+  overlay.innerHTML = `
+    <div class="w-[92%] max-w-md rounded-2xl border ${accent} bg-zinc-900/95 p-6 ${glow}">
+      <h2 class="text-3xl font-extrabold tracking-wide ${didWin ? 'text-green-300' : 'text-red-300'}">
+        ${title}
+      </h2>
+      <div class="mt-5 rounded-lg bg-zinc-800/70 p-3">
+        <p class="text-sm text-zinc-400">Result</p>
+        <p class="text-base text-white">
+          ${winnerName ? `${winnerName} wins` : (didWin ? 'Victory' : 'Defeat')}
+        </p>
+      </div>
+      <div class="mt-6 flex justify-end gap-2">
+        <button id="pongResultOkBtn"
+          class="rounded-lg bg-violet-600 px-4 py-2 text-white hover:bg-violet-500">
+          Continue
+        </button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  const close = () => overlay.remove();
+  document.getElementById('pongResultOkBtn')?.addEventListener('click', close, { once: true });
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) close();
+  });
+}
+
 // --- Game Variables ---
 let ws = null;
 let currentGameId = null;
@@ -95,8 +132,8 @@ export function joinOnlineGame(gameId, IsTournament) {
   if (IsTournament) {
     sessionStorage.setItem('activeTournamentId', window.currentTournamentId);
   }
-  const currentUserId = String(window.CURRENT_USER?.user_id ?? '');
-  const currentUsername = window.CURRENT_USER?.username || 'Player';
+  const currentUsername = localStorage.getItem('username') || window.CURRENT_USER?.username || 'Player';
+  let assignedUserId = null;
   const canvas = createGameCanvas();
 
   const engine = new Engine(canvas, true);
@@ -228,6 +265,11 @@ export function joinOnlineGame(gameId, IsTournament) {
 
       if (data.type === "assign") {
         console.log("Assigned role:", data.role);
+        const parsedAssignedId = Number(data.user_id);
+        if (Number.isFinite(parsedAssignedId)) {
+          assignedUserId = parsedAssignedId;
+          localStorage.setItem('user_id', String(parsedAssignedId));
+        }
 
         
 
@@ -255,21 +297,22 @@ export function joinOnlineGame(gameId, IsTournament) {
           waitingModal.remove();
         }
 
-        showMessage(`${data.winner} wins!`)
-        const userId = String(window.CURRENT_USER?.user_id ?? '');
+        const localUserId = Number(localStorage.getItem('user_id'));
+        const currentUserId = Number.isFinite(assignedUserId) ? assignedUserId : localUserId;
+        showPongResultModal({
+          winnerId: data.winner_id,
+          winnerName: data.winner,
+          currentUserId,
+        });
+        const userId = String(Number.isFinite(currentUserId) ? currentUserId : '');
         const myAchievements = (data.new_achievements || {})[userId] || [];
         showAchievements(myAchievements);
-        console.log("after yes");
         // Clean up event listeners and intervals
         clearInterval(keyboardInterval);
         window.removeEventListener("pointermove", pointerHandler);
         window.removeEventListener("keydown", keyDownHandler);
         window.removeEventListener("keyup", keyUpHandler);
-        console.log("data:", data);
-        console.log("gameId:", gameId);
-        console.log("data.winner.id:", data.winner_id);
-        console.log("window.CURRENT_USER?.user_id:", String(window.CURRENT_USER?.user_id));
-
+       
         if (window.gameObjects) {
           scene.dispose();
           engine.dispose();
@@ -315,7 +358,10 @@ export function joinOnlineGame(gameId, IsTournament) {
 
 
 export async function joinMatchmaking(){
-  const res = await fetch('api/game/join', { method: 'POST'});
+  const res = await fetch('/api/game/join', { 
+    method: 'POST',
+    credentials: 'include',
+  });
 
   if (!res.ok){
     const text = await res.text();

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -188,6 +188,16 @@ export function joinOnlineGame(gameId, IsTournament) {
       </div>
     </div>
     `;
+
+    document.getElementById('leaveWaitingBtn')?.addEventListener('click', () => {
+        gameEnded = true;
+        ws?.close();
+        ws = null;
+        isGameActive = false;
+        sessionStorage.removeItem('activeGameId');
+        sessionStorage.removeItem('activeTournamentId');
+        navigate('/');
+    })
   };
 
   ws.onerror = (e) => console.error("WS error", e);

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -112,11 +112,11 @@ export function joinOnlineGame(gameId, IsTournament) {
   // Connect to backend on port 3000 (not vite dev server on 5173)
   const wsHost = import.meta.env.DEV ? 'localhost:3000' : location.host;
 
-  console.log("DEV import:", import.meta.env.DEV);
-  console.log("WS Host:", wsHost);
-  console.log("location.host:", location.host);
+  // console.log("DEV import:", import.meta.env.DEV);
+  // console.log("WS Host:", wsHost);
+  // console.log("location.host:", location.host);
 
-  const url = `${proto}//${location.host}/ws/${gameId}`;
+  const url = `${proto}//${wsHost}/ws/${gameId}`;
   ws = new WebSocket(url);
 
   ws.onopen = () => {
@@ -308,7 +308,19 @@ export function joinOnlineGame(gameId, IsTournament) {
       navigate(`/tournament/${window.currentTournamentId}`);
     } else {
       console.log("DIBADIBADIBADOEDOE\n");
-      navigate('/online');
+      navigate('/');
     }
   };
+}
+
+
+export async function joinMatchmaking(){
+  const res = await fetch('api/game/join', { method: 'POST'});
+
+  if (!res.ok){
+    const text = await res.text();
+    throw new Error('join failed ${res.status}: ${text}');
+  }
+  const { gameId } = await res.json();
+  joinOnlineGame(gameId, false);
 }

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -181,8 +181,6 @@ export function joinOnlineGame(gameId, IsTournament) {
         <div class="bg-gray-900 border-2 border-green-400 rounded-lg p-8 text-center">
           <h2 class="text-white text-2xl font-bold mb-4">Waiting for opponent...</h2>
           <p class="text-gray-300 mb-2">Game will start soon</p>
-          <div class="text-4xl font-mono font-bold text-green-400 mb-6" id="countdownTimer">60</div>
-          <p class="text-gray-400 text-sm mb-6">Game will proceed automatically when timer expires</p>
           <button id="leaveWaitingBtn" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-6 rounded">
             Leave Game
           </button>
@@ -277,14 +275,6 @@ export function joinOnlineGame(gameId, IsTournament) {
         const playerNameElem = document.getElementById(`playerName${data.role}`);
         if (playerNameElem) {
           playerNameElem.textContent = currentUsername;
-        }
-      }
-
-      if (data.type === "timeUpdate") {
-        // Update countdown timer
-        const timerElem = document.getElementById("countdownTimer");
-        if (timerElem) {
-          timerElem.textContent = data.remaining_time;
         }
       }
 

--- a/frontend/src/routes/route_helpers.js
+++ b/frontend/src/routes/route_helpers.js
@@ -3,10 +3,21 @@ import { routes } from "../main.js";
 import { updatePageTranslations } from '../i18n/index.js';
 import { handleTournamentRoute } from './routes.js';
 import { closeChessConnection } from "../chess/chess-online.js";
+import { isGameActive } from "../pong/game/game.js";
+import { closeGameConnection } from "../pong/game/game.js";
 
 export function navigate(path) {
-    if (window.location.pathname === '/chess-online' && path !== '/chess-online'){
+    const currentPath = window.location.pathname;
+    //close chess socket when leaving chess online path
+    if (currentPath === '/chess-online' && path !== '/chess-online'){
         closeChessConnection();
+    }
+
+    //close pong socket when user navgates away from the game
+    if (isGameActive && currentPath !== path){
+        closeGameConnection();
+        sessionStorage.removeItem('activeGameId');
+        sessionStorage.removeItem('activeTournamentId');
     }
     window.history.pushState({}, path, window.location.origin + path);
     handleRoute(path);

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -233,154 +233,18 @@ export function setupRoutes() {
 
   routes['/online'] = async () => {
     stopTournamentAutoRefresh();
-    if(await redirectIfNotLoggedIn())
+    if (await redirectIfNotLoggedIn())
 			return;
-    // disposeCurrentEngine();
-    if (await checkAuthRequired() == true)
-      {
-      showMessage('You need to be logged in to access online games.', 'error');
-      return;
-    }
-
-    // If we landed here with a gameId query param (e.g. from a tournament start), join the game right away
     const params = new URLSearchParams(window.location.search);
     const gameId = params.get('gameId');
-    if (gameId) {
+    if (gameId){
+      window.history.replaceState({}, '', '/online');
       joinOnlineGame(gameId, false);
-
-      // Drop the query param so popstate/back does not re-join repeatedly
-      params.delete('gameId');
-      const newUrl = `${window.location.pathname}${params.toString() ? `?${params}` : ''}`;
-      window.history.replaceState({}, '', newUrl);
+      return;
     }
-
-    await loadTemplate('online');
-
-    // Load current user's match history and achievements
-    fetchWithRefreshAuth('/api/auth/me')
-      .then(r => r.json())
-      .then(me => {
-        fetchWithRefreshAuth('/api/match-history')
-          .then(r => r.json())
-          .then(data => {
-            const tbody = document.getElementById('pong-history-table');
-            if (!tbody) return;
-            if (!data.matches || data.matches.length === 0) {
-              tbody.innerHTML = '<tr><td colspan="4" class="text-gray-400 pt-1">No games yet.</td></tr>';
-              return;
-            }
-            tbody.innerHTML = data.matches.slice(0, 10)
-              .map(m => {
-                const opponent = m.player1 === me.username ? m.player2 : m.player1;
-                const myScore = m.player1 === me.username ? m.player1_score : m.player2_score;
-                const oppScore = m.player1 === me.username ? m.player2_score : m.player1_score;
-                const won = m.winner === me.username;
-                const result = m.winner
-                  ? (won ? '<span class="text-green-400">Win</span>' : '<span class="text-red-400">Loss</span>')
-                  : '<span class="text-gray-400">-</span>';
-                const date = new Date(m.timestamp).toLocaleDateString();
-                return `<tr class="border-t border-white/10">
-                  <td class="py-1 pr-2">${opponent}</td>
-                  <td class="py-1 pr-2 font-semibold">${myScore}–${oppScore}</td>
-                  <td class="py-1 pr-2">${result}</td>
-                  <td class="py-1 text-gray-400">${date}</td>
-                </tr>`;
-              })
-              .join('');
-          })
-          .catch(() => {
-            const tbody = document.getElementById('pong-history-table');
-            if (tbody) tbody.innerHTML = '<tr><td colspan="4" class="text-gray-400">Could not load.</td></tr>';
-          });
-
-        return fetchWithRefreshAuth(`/api/player/${me.username}/achievements`);
-      })
-      .then(r => r.json())
-      .then(data => {
-        const list = document.getElementById('pong-achievements-list');
-        if (!list) return;
-        if (!data.achievements || data.achievements.length === 0) {
-          list.innerHTML = '<li class="text-gray-400">No achievements yet.</li>';
-          return;
-        }
-        list.innerHTML = data.achievements
-          .map(a => `<li><b>${a.name}</b>: ${a.description}</li>`)
-          .join('');
-      })
-      .catch(() => {
-        const list = document.getElementById('pong-achievements-list');
-        if (list) list.innerHTML = '<li class="text-gray-400">Could not load.</li>';
-      });
-
-    // Bottom table: latest 10 achievements across all players
-    fetchWithRefreshAuth('/api/achievements')
-      .then(r => r.json())
-      .then(data => {
-        const tbody = document.getElementById('pong-results-table');
-        if (!tbody) return;
-        if (!data.achievements || data.achievements.length === 0) {
-          tbody.innerHTML = '<tr><td colspan="3" class="text-gray-400 pt-1">No achievements yet.</td></tr>';
-          return;
-        }
-        tbody.innerHTML = data.achievements
-          .map(a => {
-            const date = new Date(a.timestamp).toLocaleDateString();
-            return `<tr class="border-t border-white/10">
-              <td class="py-1 pr-3 font-semibold">${a.player_name}</td>
-              <td class="py-1 pr-3 text-orange-300">${a.achievement_name}</td>
-              <td class="py-1 text-gray-400">${date}</td>
-            </tr>`;
-          })
-          .join('');
-      })
-      .catch(() => {
-        const tbody = document.getElementById('pong-results-table');
-        if (tbody) tbody.innerHTML = '<tr><td colspan="3" class="text-gray-400">Could not load.</td></tr>';
-      });
-
-    document.getElementById('backBtn')?.addEventListener('click', () => navigate('/'));
-
-    document.getElementById('refreshGamesBtn')?.addEventListener('click', async () => {
-      const response = await fetch('/api/games', { method: 'GET' });
-      const data = await response.json();
-      const availableGamesDiv = document.getElementById('availableGames');
-      availableGamesDiv.innerHTML = '<h3 class="text-white">Available Games:</h3>';
-      if (!data.games || data.games.length === 0) {
-        availableGamesDiv.innerHTML += '<p class="text-gray-300">No available games.</p>';
-      } else {
-        data.games.forEach((game) => {
-          console.log("Processing game:", game);
-          if (game.isTournamentGame == true)
-          {
-            // Skip tournament games
-            return;
-          }
-          const gameBtn = document.createElement('button');
-          gameBtn.textContent = `Join Game ${game.id}`;
-          gameBtn.className = 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded m-1';
-          console.log("Adding join button for game ID:", game.id);
-          gameBtn.addEventListener('click', () => joinOnlineGame(game.id));
-          const gameStatusDiv = document.createElement('div');
-          gameStatusDiv.className = 'text-white';
-          gameStatusDiv.innerHTML = `<p>Status: ${game.status}</p>`;
-          availableGamesDiv.appendChild(gameBtn);
-          availableGamesDiv.appendChild(gameStatusDiv);
-        });
-      }
-    });
-
-    document.getElementById('createGameBtn')?.addEventListener('click', async () => {
-      try {
-        const response = await fetch('/api/game/create', { method: 'POST' });
-        const data = await response.json();
-        document.getElementById('lobbyStatus').innerHTML = `<p class="text-green-400">Game created with ID: ${data.gameId}.</p>`;
-      } catch (error) {
-        console.error('Failed to create game:', error);
-        document.getElementById('lobbyStatus').innerHTML = `<p class="text-red-400">Failed to create game. Please try again.</p>`;
-        showMessage('Failed to create game. Please try again.', 'error');
-      }
-    });
+    navigate('/');
   };
+
   routes['/profile'] = async () => {
     stopTournamentAutoRefresh();
     if(await redirectIfNotLoggedIn())


### PR DESCRIPTION
This branch delivers a complete online Pong matchmaking flow. A new /api/game/join endpoint handles matchmaking — joining an existing open game or creating a new one with a randomly assigned side. The frontend wires the "Play Ranked" button directly to joinMatchmaking(), bypassing the old /online lobby page (which has been gutted in favour of the direct join). A result modal (showPongResultModal) replaces the previous alert-based outcome display, and the game now navigates back to / (not /online) on exit. Reliability fixes include: properly closing the game WebSocket on beforeunload/navigation, guarding the timeout checker so it only fires for tournament games, deduplicating connections via the clients set, and — critically — fixing the disconnect handler to pass the pre-removal player snapshot to match_ends (so the server-side gameOver broadcast is always sent when an opponent leaves) and removing the Babylon canvas from document.body before navigating away so it never overlays the next page.