### PR TITLE
cleaned up 2 event listeners that were never removed

### DIFF
--- a/frontend/src/home/home.js
+++ b/frontend/src/home/home.js
@@ -1,6 +1,8 @@
 import { navigate } from "../routes/route_helpers.js";
 import { setChessOnlineIntended } from "../routes/routes.js";
 
+let _keydownHandler = null;
+
 export function initHome() {
     const username = localStorage.getItem('username');
     
@@ -82,11 +84,15 @@ export function initHome() {
         else
             navigate('/chess');
     });
-
-    document.addEventListener('keydown', (e) => {
+    if (_keydownHandler){
+        document.removeEventListener('keydown', _keydownHandler);
+    }
+    _keydownHandler = (e) => {
         if(e.key === 'Escape')
             closeOnlinePanel();
-    })
+
+    }
+    document.addEventListener('keydown', _keydownHandler);
 }
 
 function updateAiBtnForMode(mode){

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -105,6 +105,7 @@ export function joinOnlineGame(gameId, IsTournament) {
   let keyboardInterval = null;
   let keyDownHandler = null;
   let keyUpHandler = null;
+  let resizeHandler = null;
   let gameEnded = false;
 
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
@@ -184,7 +185,9 @@ export function joinOnlineGame(gameId, IsTournament) {
         window.gameObjects = initGameScene(scene, canvas, 2);
 
         engine.runRenderLoop(() => scene.render());
-        window.addEventListener("resize", () => engine.resize());
+
+        resizeHandler = () => engine.resize();
+        window.addEventListener("resize", resizeHandler);
 
         // Paddle movement with mouse
         pointerHandler = (e) => {
@@ -265,10 +268,7 @@ export function joinOnlineGame(gameId, IsTournament) {
         window.removeEventListener("pointermove", pointerHandler);
         window.removeEventListener("keydown", keyDownHandler);
         window.removeEventListener("keyup", keyUpHandler);
-        console.log("data:", data);
-        console.log("gameId:", gameId);
-        console.log("data.winner.id:", data.winner_id);
-        console.log("window.CURRENT_USER?.user_id:", String(window.CURRENT_USER?.user_id));
+        window.removeEventListener("resize", resizeHandler);
 
         if (window.gameObjects) {
           scene.dispose();
@@ -297,6 +297,7 @@ export function joinOnlineGame(gameId, IsTournament) {
       window.removeEventListener("pointermove", pointerHandler);
       window.removeEventListener("keydown", keyDownHandler);
       window.removeEventListener("keyup", keyUpHandler);
+      window.removeEventListener("resize", resizeHandler);
       scene.dispose();
       engine.dispose();
       // Clear session storage


### PR DESCRIPTION
Fix event listener leaks on document (home keydown) and window (game resize) that accumulated on every route visit or game session by storing handlers in named variables and removing them in all paths.
