### PR TITLE
feat(chat/pong): pong game invites from chat, and global result announcements

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -287,7 +287,19 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		}))
 
 	async def game_result(self, event):
-		pass
+		winner = event.get("winner")
+		loser = event.get("loser")
+		game_type = event.get("game_type", "game")
+		if winner and loser:
+			msg = f"{winner} beat {loser} in a game of {game_type}!"
+		elif winner:
+			msg = f"{winner} won a game of {game_type}!"
+		else:
+			msg = f"A game of {game_type} ended in a draw."
+		await self.send(text_data=json.dumps({
+			"type": "game_result",
+			"message": msg,
+		}))
 
 	async def trigger_online_users_broadcast(self, event):
 		logger.debug(f"[broadcast] IN_GAME_USERS at broadcast time: {IN_GAME_USERS}")

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -96,10 +96,13 @@ class ChessConsumer(AsyncWebsocketConsumer):
 				await self.save_chess_result(self.game, winner, 'abandonment')
 
 				#announce result to global chat
+				loser_color = 'black' if winner == 'white' else 'white'
 				winner_name = getattr(self.game.players[winner], 'username', winner)
+				loser_name = getattr(self.game.players[loser_color], 'username', None)
 				await self.channel_layer.group_send('global_chat', {
-					'type': 'game.result',
+					'type': 'game_result',
 					'winner': winner_name,
+					'loser': loser_name,
 					'game_type': 'chess',
 					'is_tournament': False
 				})
@@ -164,11 +167,15 @@ class ChessConsumer(AsyncWebsocketConsumer):
 			winner_color = over['winner']
 			if winner_color:
 				winner_name = getattr(self.game.players[winner_color], 'username', winner_color)
+				loser_color = 'black' if winner_color == 'white' else 'white'
+				loser_name = getattr(self.game.players[loser_color], 'username', None)
 			else:
 				winner_name = None
+				loser_name = None
 			await self.channel_layer.group_send('global_chat', {
-				'type': 'game.result',
+				'type': 'game_result',
 				'winner': winner_name,
+				'loser': loser_name,
 				'game_type': 'chess',
 				'is_tournament': False
 			})

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -8,6 +8,7 @@ from channels.db import database_sync_to_async
 from .models import GameSession, Player
 from .services import match_ends
 import logging
+from chat.consumers import IN_GAME_USERS
 
 logger = logging.getLogger(__name__)
 
@@ -226,11 +227,30 @@ class GameConsumer(AsyncWebsocketConsumer):
         }))
         logger.debug(f"Start game?: {self.game.can_start()}")
 
+        # Mark this player unavailable for invites as soon as they enter any pong session.
+        IN_GAME_USERS.add(str(user_id))
+
         # Start game if both players connected
         if self.game.can_start():
             self.game.start_game()
             # Update tournament game status to ongoing
             await sync_to_async(update_game_to_ongoing)(self.game_id)
+
+            player_ids = [str(pid) for pid in self.game.players_ids.values() if pid]
+            for pid in player_ids:
+                IN_GAME_USERS.add(pid)
+            await self.channel_layer.group_send('global_chat', {'type': 'trigger.online.users.broadcast'})
+
+            # Expire any pending invites between these two players
+            if len(player_ids) == 2:
+                invite_ids = await self.get_invite_ids_between(player_ids[0], player_ids[1])
+                for gid in invite_ids:
+                    for uid in player_ids:
+                        await self.channel_layer.group_send(
+                            f'user_{uid}',
+                            {'type': 'game.invite.expired', 'game_id': gid}
+                        )
+
             # Refresh players after start
             players = self.game.get_players()
             p1 = players.get('left')
@@ -248,6 +268,7 @@ class GameConsumer(AsyncWebsocketConsumer):
             # Start game loop
             asyncio.create_task(self.game_loop())
         else:
+            await self.channel_layer.group_send('global_chat', {'type': 'trigger.online.users.broadcast'})
             if self.game.isTournamentGame:
                 # Start timeout checker if this is a tournament game in waiting state
                 asyncio.create_task(self.check_join_timeout())
@@ -300,15 +321,25 @@ class GameConsumer(AsyncWebsocketConsumer):
                         'new_achievements': new_achievements,
                     }
                 )
+                loser_name = getattr(departing_user, 'username', None)
                 await self.channel_layer.group_send(
-                    "global_chat",                                                               
-                    {           
+                    "global_chat",
+                    {
                         "type": "game_result",
-                        "winner": winner_name,              
-                        "game_type": "pong",        # or "chess"
+                        "winner": winner_name,
+                        "loser": loser_name,
+                        "game_type": "pong",
                         "is_tournament": self.game.isTournamentGame
-                    }                                                                            
+                    }
                 )
+
+            elif status_before == 'waiting' and getattr(self.game, 'invitee_id', None) is not None:
+                invitor_id = str(getattr(departing_user, 'id', None))
+                for uid in [self.game.invitee_id, invitor_id]:
+                    await self.channel_layer.group_send(
+                        f'user_{uid}',
+                        {'type': 'game.invite.expired', 'game_id': self.game_id}
+                    )
 
             # If all players are gone, reset game to waiting state
             players = self.game.get_players()
@@ -317,7 +348,7 @@ class GameConsumer(AsyncWebsocketConsumer):
                 self.game.status = 'waiting'
                 # Update tournament game status in database
                 await sync_to_async(reset_game_to_ready)(self.game_id)
-            
+
             if self.game.status == 'completed' and status_before != 'active':
                 await self.channel_layer.group_send(
                     self.game_group_name,
@@ -328,15 +359,21 @@ class GameConsumer(AsyncWebsocketConsumer):
                     }
                 )
                 await self.channel_layer.group_send(
-                    "global_chat",                                                               
-                    {           
+                    "global_chat",
+                    {
                         "type": "game_result",
-                        "winner": None,              
-                        "game_type": "pong",        # or "chess"
+                        "winner": None,
+                        "game_type": "pong",
                         "is_tournament": self.game.isTournamentGame
-                    }                                                                            
+                    }
                 )
-        
+
+            # Remove all players from in-game tracking
+            for player_id in self.game.players_ids.values():
+                if player_id:
+                    IN_GAME_USERS.discard(str(player_id))
+            await self.channel_layer.group_send('global_chat', {'type': 'trigger.online.users.broadcast'})
+
         if hasattr(self, 'game_group_name'):
             await self.channel_layer.group_discard(
                 self.game_group_name,
@@ -384,6 +421,9 @@ class GameConsumer(AsyncWebsocketConsumer):
                     self.game.status = "completed"
                     await sync_to_async(update_game_completed)(self.game_id, winner_id, winner_name)
 
+                    loser_user = players['right'] if result.get('winner') == 'left' else players['left']
+                    loser_name = getattr(loser_user, 'username', None)
+
                     # Run DB work in sync thread; pass users and resolve profiles in service.
                     result_data = await database_sync_to_async(match_ends)(
                         self.game,
@@ -399,6 +439,16 @@ class GameConsumer(AsyncWebsocketConsumer):
                             'winner': winner_name,
                             'winner_id': winner_id,
                             'new_achievements': new_achievements,
+                        }
+                    )
+                    await self.channel_layer.group_send(
+                        'global_chat',
+                        {
+                            'type': 'game_result',
+                            'winner': winner_name,
+                            'loser': loser_name,
+                            'game_type': 'pong',
+                            'is_tournament': self.game.isTournamentGame,
                         }
                     )
                     break
@@ -499,3 +549,19 @@ class GameConsumer(AsyncWebsocketConsumer):
     async def close_connection(self, event):
         """Close the websocket connection"""
         await self.close(code=1008)
+
+    @sync_to_async
+    def get_invite_ids_between(self, user1_id, user2_id):
+        from chat.models import GameInvite, ConversationParticipant
+        conv_ids = ConversationParticipant.objects.filter(
+            user_id=user1_id
+        ).values_list('conversation_id', flat=True)
+        shared_conv_id = ConversationParticipant.objects.filter(
+            conversation_id__in=conv_ids,
+            user_id=user2_id
+        ).values_list('conversation_id', flat=True).first()
+        if not shared_conv_id:
+            return []
+        return list(GameInvite.objects.filter(
+            conversation_id=shared_conv_id
+        ).values_list('game_id', flat=True))

--- a/backend/game/views.py
+++ b/backend/game/views.py
@@ -15,11 +15,24 @@ logger = logging.getLogger(__name__)
 @csrf_exempt
 @require_http_methods(["POST"])
 def create_game(request):
+    user, error = get_authenticated_user(request)
+    if error:
+        return error
+
+    invitee_id = None
+    try:
+        if request.body:
+            payload = json.loads(request.body.decode('utf-8'))
+            invitee_id = payload.get('invitee_id')
+    except Exception:
+        pass
+
     game = GameSession.create_game()
     game.isTournamentGame = False
+    if invitee_id is not None:
+        game.invitee_id = str(invitee_id)
 
-    # Use logging so output is captured by gunicorn/daphne/docker logs
-    logger.info(f"Created game with ID: {game.id}")
+    logger.info(f"Created game with ID: {game.id}, invitee_id={invitee_id}")
     return JsonResponse({
         'gameId': game.id,
         'status': 'waiting',

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -102,6 +102,8 @@
 		<div class="px-4 py-2 text-xs text-pink-300 font-bold border-b border-pink-600/20">Choose a game</div>
 		<button data-game="chess"
 			class="block w-full px-4 py-2 text-left text-sm text-[#fce7f3] hover:text-[#4ade80] transition-colors">Chess</button>
+		<button data-game="pong"
+			class="block w-full px-4 py-2 text-left text-sm text-[#fce7f3] hover:text-[#4ade80] transition-colors">Pong</button>
 	</div>
 	<script type="module" src="src/main.js"></script>
 

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -193,7 +193,7 @@ export function initChatUI() {
 							handleRoute('/chess-online');
 						} else {
 							window.history.pushState({}, '', `/online?gameId=${msg.invite.gameId}`);
-							navigate('/online');
+							handleRoute('/online');
 						}
 					});
 					msgDiv.appendChild(acceptBtn);
@@ -494,6 +494,30 @@ export function initChatUI() {
 			// pendingInvite stays true until A leaves /chess-online
 			window.history.pushState({}, '', `/chess-online?gameId=${gameId}`);
 			handleRoute('/chess-online');
+		} else if (gameType === "pong") {
+			const res = await fetchWithRefreshAuth('/api/game/create', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ invitee_id: targetId })
+			});
+			if (!res.ok) {
+				pendingInvite = false;
+				showMessage("Could not create game. Please try again.", "error");
+				return;
+			}
+			const data = await res.json();
+			const gameId = data.gameId;
+			sendGameInvite(targetId, "pong", gameId);
+			openDMChannel(targetId, targetName, true, false);
+			addMessage(targetId, {
+				senderId: verifiedUserId,
+				senderName: null,
+				recipientName: targetName,
+				invite: { gameType: "pong", gameId }
+			});
+			// pendingInvite stays true until pong game ends
+			window.history.pushState({}, '', `/online?gameId=${gameId}`);
+			handleRoute('/online');
 		}
 	});
 
@@ -516,6 +540,10 @@ export function initChatUI() {
 	});
 
 	window.addEventListener("chessGameLeft", () => {
+		pendingInvite = false;
+	});
+
+	window.addEventListener("pongGameLeft", () => {
 		pendingInvite = false;
 	});
 

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -151,6 +151,19 @@ export function initChat() {
 				}));
 				break;
 
+			case "game_result":
+				window.dispatchEvent(new CustomEvent("chatMessageReceived", {
+					detail: {
+						channelId: "global",
+						message: {
+							senderId: null,
+							senderName: "🏆 Game Result",
+							message: data.message
+						}
+					}
+				}));
+				break;
+
 			// Another user started typing — show indicator (TODO in UI)
 			case "typing":
 				console.log(`${data.name || data.user} is typing...`);

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -1,4 +1,5 @@
 import { createGameCanvas } from "../../routes/routes.js";
+import { fetchWithRefreshAuth } from "../../users_friends/usermanagement.js";
 
 import {
   ArcRotateCamera,
@@ -360,14 +361,13 @@ export function joinOnlineGame(gameId, IsTournament) {
 
 
 export async function joinMatchmaking(){
-  const res = await fetch('/api/game/join', {
+  const res = await fetchWithRefreshAuth('/api/game/join', {
     method: 'POST',
-    credentials: 'include',
   });
 
   if (!res.ok){
     const text = await res.text();
-    throw new Error('join failed ${res.status}: ${text}');
+    throw new Error(`join failed ${res.status}: ${text}`);
   }
   const { gameId } = await res.json();
   joinOnlineGame(gameId, false);

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -196,6 +196,7 @@ export function joinOnlineGame(gameId, IsTournament) {
         isGameActive = false;
         sessionStorage.removeItem('activeGameId');
         sessionStorage.removeItem('activeTournamentId');
+        window.dispatchEvent(new CustomEvent("pongGameLeft"));
         navigate('/');
     })
   };
@@ -351,7 +352,7 @@ export function joinOnlineGame(gameId, IsTournament) {
     if (IsTournament) {
       navigate(`/tournament/${window.currentTournamentId}`);
     } else {
-      console.log("DIBADIBADIBADOEDOE\n");
+      window.dispatchEvent(new CustomEvent("pongGameLeft"));
       navigate('/');
     }
   };
@@ -359,7 +360,7 @@ export function joinOnlineGame(gameId, IsTournament) {
 
 
 export async function joinMatchmaking(){
-  const res = await fetch('/api/game/join', { 
+  const res = await fetch('/api/game/join', {
     method: 'POST',
     credentials: 'include',
   });


### PR DESCRIPTION
index.html: 
- added "Pong" button to gamePickerMenu dropdown so users can pick pong (alongside chess) when sending a game invite from a DM

Pong invite flow (mirrors chess):
- chat-ui.js: invitor hits "Pong" → POST /api/game/create with invitee_id, sends game_invite over WS, navigates to /online?gameId=... via handleRoute
(not navigate) to preserve the query param
- chat-ui.js: accept button for pong invites now uses handleRoute('/online') instead of navigate('/online'):
navigate was pushing a new history entry and losing the ?gameId= param, so the route fell back to home
- chat-ui.js: added pongGameLeft listener to reset pendingInvite flag

game/views.py: create_game now authenticates the caller and parses invitee_id from the request body, storing it on the in-memory GameSession
This is required so the disconnect handler knows who to notify when the invitor navigates away before the game starts

game/consumers.py:
- Import IN_GAME_USERS from chat.consumers
- On connect: add player to IN_GAME_USERS immediately; on game start add  both players, broadcast online users update,
expire any pending invites between the two players (get_invite_ids_between, identical to chess)
- On disconnect (waiting + invitee_id set): send game.invite.expired to both invitor and invitee so the Accept button disappears
- On disconnect and game_loop end: discard both players from IN_GAME_USERS and broadcast online users update
- game_loop: broadcast game_result to global_chat with winner, loser, and game_type so the result appears in global chat
- Added get_invite_ids_between method (sync_to_async DB query)

chessgame/consumers.py:
- Fixed type 'game.result' → 'game_result' (dot caused Django Channels routing to fail silently; underscores are required)
- Added loser_name to both game_result broadcasts (disconnect abandonment and normal game end via receive)

chat/consumers.py: implemented game_result handler (was a pass stub)
formats "X beat Y in a game of pong/chess!" and sends to all global chat connections

chat.js: added game_result case that dispatches chatMessageReceived to global channel so the result message renders in the UI

pong/game/game.js:
- Dispatch pongGameLeft custom event in both ws.onclose (non-tournament) and leaveWaitingBtn click handler so chat-ui.js can clear pendingInvite
- Remove stale console.log ("DIBADIBADIBADOEDOE")
- replace plain fetch() with fetchWithRefreshAuth so expired access tokens are refreshed automatically instead of returning 401                                                                                                                                                                                              
- fix error message template literal (single quotes → backticks) so status and body are interpolated correctly                                 