### PR TITLE
chess stats and endpoints ready

### DIFF
--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -244,14 +244,24 @@ class ChessConsumer(AsyncWebsocketConsumer):
 
 			if winner == 'white':
 				white_result, black_result = 1, 0
+				result_str = '1-0'
+				white_cp.total_wins += 1
+				black_cp.total_losses += 1
 			elif winner == 'black':
 				white_result, black_result = 0, 1
+				result_str = '0-1'
+				white_cp.total_losses += 1
+				black_cp.total_wins += 1
 			else:
 				white_result, black_result = 0.5, 0.5
+				result_str = '1/2-1/2'
 			
 			#update players' elo
 			white_cp.update_elo(black_elo_before, white_result)
 			black_cp.update_elo(white_elo_before, black_result)
+
+			white_cp.total_games += 1
+			black_cp.total_games += 1
 
 			ChessMatch.objects.create(
 				white=white_cp,

--- a/backend/chessgame/models.py
+++ b/backend/chessgame/models.py
@@ -104,6 +104,10 @@ class ChessPlayer(models.Model):
 			self.total_losses += 1
 		self.save()
 
+	@classmethod
+	def get_leaderboard(cls):
+		return cls.objects.select_related('user').order_by('-elo_rating')[:10]
+
 class ChessMatch(models.Model):
 	white = models.ForeignKey(ChessPlayer, on_delete=models.SET_NULL, null = True, related_name='games_as_white')
 	black = models.ForeignKey(ChessPlayer, on_delete=models.SET_NULL, null = True, related_name='games_as_black')

--- a/backend/chessgame/urls.py
+++ b/backend/chessgame/urls.py
@@ -3,4 +3,7 @@ from . import views
 
 urlpatterns = [
 	path('chess/join/', views.join_chess, name='chess_join'),
+	path('chess/stats/', views.chess_stats, name='chess_stats'),
+	path('chess/leaderboard/', views.chess_leaderboard, name='chess_leaderboard'),
+	path('chess/match-history/', views.chess_match_history, name='chess_match_history'),
 ]

--- a/backend/chessgame/views.py
+++ b/backend/chessgame/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 import logging
 import random
 import json
-from .models import ChessSession
+from .models import ChessSession, ChessPlayer, ChessMatch
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -66,3 +66,73 @@ def join_chess(request):
 
 	logger.info(f"Player {user} created game {game.id} as {color}")
 	return JsonResponse({'gameId': game.id})
+
+
+@require_http_methods(["GET"])
+def chess_stats(request):
+	user = get_user_from_access_cookie(request)
+	if not user:
+		return JsonResponse({'error': 'Authentication required'}, status=401)
+	try:
+		player = ChessPlayer.objects.get(user=user)
+	except ChessPlayer.DoesNotExist:
+		return JsonResponse({'total_games': 0, 'total_wins': 0, 'total_losses': 0, 'elo_rating': 1200})
+	return JsonResponse({
+		'total_games': player.total_games,
+		'total_wins': player.total_wins,
+		'total_losses': player.total_losses,
+		'elo_rating': player.elo_rating,
+	})
+
+
+@require_http_methods(["GET"])
+def chess_leaderboard(request):
+	players = ChessPlayer.get_leaderboard()
+	leaderboard = [
+		{
+			'username': p.user.username,
+			'elo_rating': p.elo_rating,
+			'total_wins': p.total_wins,
+			'total_games': p.total_games,
+		}
+		for p in players
+	]
+	return JsonResponse({'leaderboard': leaderboard})
+
+
+@require_http_methods(["GET"])
+def chess_match_history(request):
+	user = get_user_from_access_cookie(request)
+	if not user:
+		return JsonResponse({'error': 'Authentication required'}, status=401)
+	try:
+		player = ChessPlayer.objects.get(user=user)
+	except ChessPlayer.DoesNotExist:
+		return JsonResponse({'matches': []})
+	matches_qs = ChessMatch.objects.filter(
+		white=player
+	).union(
+		ChessMatch.objects.filter(black=player)
+	).order_by('-timestamp')[:20]
+	matches = []
+	for m in matches_qs:
+		white_user = m.white.user.username if m.white and m.white.user else '?'
+		black_user = m.black.user.username if m.black and m.black.user else '?'
+		is_white = m.white_id == player.id
+		opponent = black_user if is_white else white_user
+		if m.result == '1-0':
+			winner = white_user
+		elif m.result == '0-1':
+			winner = black_user
+		else:
+			winner = None
+		matches.append({
+			'white': white_user,
+			'black': black_user,
+			'opponent': opponent,
+			'result': m.result,
+			'winner': winner,
+			'timestamp': m.timestamp.isoformat(),
+		})
+	return JsonResponse({'matches': matches})
+

--- a/backend/fixtures/users.json
+++ b/backend/fixtures/users.json
@@ -644,8 +644,8 @@
   "fields": {
     "user": 1,
     "elo_rating": 1240,
-    "total_games": 5,
-    "total_wins": 3,
+    "total_games": 3,
+    "total_wins": 1,
     "total_losses": 2
   }
 },
@@ -655,8 +655,8 @@
   "fields": {
     "user": 2,
     "elo_rating": 1185,
-    "total_games": 4,
-    "total_wins": 2,
+    "total_games": 3,
+    "total_wins": 1,
     "total_losses": 2
   }
 },
@@ -666,9 +666,9 @@
   "fields": {
     "user": 3,
     "elo_rating": 1310,
-    "total_games": 7,
-    "total_wins": 5,
-    "total_losses": 2
+    "total_games": 3,
+    "total_wins": 3,
+    "total_losses": 0
   }
 },
 {
@@ -678,7 +678,7 @@
     "user": 4,
     "elo_rating": 1160,
     "total_games": 3,
-    "total_wins": 1,
+    "total_wins": 0,
     "total_losses": 2
   }
 },
@@ -699,9 +699,9 @@
   "fields": {
     "user": 6,
     "elo_rating": 1200,
-    "total_games": 5,
-    "total_wins": 2,
-    "total_losses": 3
+    "total_games": 4,
+    "total_wins": 1,
+    "total_losses": 2
   }
 },
 {

--- a/backend/fixtures/users.json
+++ b/backend/fixtures/users.json
@@ -160,15 +160,15 @@
   "pk": 1,
   "fields": {
     "user": 1,
-    "total_games": 3,
-    "total_wins": 2,
+    "total_games": 2,
+    "total_wins": 1,
     "total_losses": 1,
     "elo_rating": 1003,
-    "total_win_points": 10,
-    "total_loss_points": 4,
-    "current_win_streak": 0,
-    "current_loss_streak": 1,
-    "best_win_streak": 2
+    "total_win_points": 5,
+    "total_loss_points": 3,
+    "current_win_streak": 1,
+    "current_loss_streak": 0,
+    "best_win_streak": 1
   }
 },
 {
@@ -177,14 +177,14 @@
   "fields": {
     "user": 2,
     "total_games": 3,
-    "total_wins": 1,
-    "total_losses": 2,
+    "total_wins": 2,
+    "total_losses": 1,
     "elo_rating": 995,
-    "total_win_points": 5,
-    "total_loss_points": 4,
-    "current_win_streak": 1,
-    "current_loss_streak": 0,
-    "best_win_streak": 1
+    "total_win_points": 10,
+    "total_loss_points": 1,
+    "current_win_streak": 0,
+    "current_loss_streak": 1,
+    "best_win_streak": 2
   }
 },
 {
@@ -192,15 +192,15 @@
   "pk": 3,
   "fields": {
     "user": 3,
-    "total_games": 6,
-    "total_wins": 4,
+    "total_games": 3,
+    "total_wins": 1,
     "total_losses": 2,
     "elo_rating": 1025,
-    "total_win_points": 21,
-    "total_loss_points": 5,
+    "total_win_points": 5,
+    "total_loss_points": 6,
     "current_win_streak": 1,
     "current_loss_streak": 0,
-    "best_win_streak": 3
+    "best_win_streak": 1
   }
 },
 {
@@ -240,14 +240,14 @@
   "pk": 6,
   "fields": {
     "user": 6,
-    "total_games": 4,
+    "total_games": 3,
     "total_wins": 2,
-    "total_losses": 2,
+    "total_losses": 1,
     "elo_rating": 1008,
-    "total_win_points": 11,
-    "total_loss_points": 6,
-    "current_win_streak": 1,
-    "current_loss_streak": 0,
+    "total_win_points": 10,
+    "total_loss_points": 4,
+    "current_win_streak": 0,
+    "current_loss_streak": 1,
     "best_win_streak": 2
   }
 },
@@ -473,15 +473,6 @@
 },
 {
   "model": "game.playerachievement",
-  "pk": 2,
-  "fields": {
-    "player": 1,
-    "achievement": 2,
-    "timestamp": "2026-03-22T10:15:34.123Z"
-  }
-},
-{
-  "model": "game.playerachievement",
   "pk": 3,
   "fields": {
     "player": 1,
@@ -541,15 +532,6 @@
     "player": 3,
     "achievement": 5,
     "timestamp": "2026-03-21T16:49:11.277Z"
-  }
-},
-{
-  "model": "game.playerachievement",
-  "pk": 10,
-  "fields": {
-    "player": 3,
-    "achievement": 6,
-    "timestamp": "2026-03-28T12:00:00.000Z"
   }
 },
 {

--- a/backend/fixtures/users.json
+++ b/backend/fixtures/users.json
@@ -637,5 +637,191 @@
   "model": "friends.block",
   "pk": 5,
   "fields": { "blocker": 6, "blocked_user": 5, "created_at": "2026-03-02T10:04:00Z" }
+},
+{
+  "model": "chessgame.chessplayer",
+  "pk": 1,
+  "fields": {
+    "user": 1,
+    "elo_rating": 1240,
+    "total_games": 5,
+    "total_wins": 3,
+    "total_losses": 2
+  }
+},
+{
+  "model": "chessgame.chessplayer",
+  "pk": 2,
+  "fields": {
+    "user": 2,
+    "elo_rating": 1185,
+    "total_games": 4,
+    "total_wins": 2,
+    "total_losses": 2
+  }
+},
+{
+  "model": "chessgame.chessplayer",
+  "pk": 3,
+  "fields": {
+    "user": 3,
+    "elo_rating": 1310,
+    "total_games": 7,
+    "total_wins": 5,
+    "total_losses": 2
+  }
+},
+{
+  "model": "chessgame.chessplayer",
+  "pk": 4,
+  "fields": {
+    "user": 4,
+    "elo_rating": 1160,
+    "total_games": 3,
+    "total_wins": 1,
+    "total_losses": 2
+  }
+},
+{
+  "model": "chessgame.chessplayer",
+  "pk": 5,
+  "fields": {
+    "user": 5,
+    "elo_rating": 1275,
+    "total_games": 4,
+    "total_wins": 3,
+    "total_losses": 1
+  }
+},
+{
+  "model": "chessgame.chessplayer",
+  "pk": 6,
+  "fields": {
+    "user": 6,
+    "elo_rating": 1200,
+    "total_games": 5,
+    "total_wins": 2,
+    "total_losses": 3
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 1,
+  "fields": {
+    "white": 3,
+    "black": 2,
+    "result": "1-0",
+    "white_elo_before": 1280,
+    "black_elo_before": 1200,
+    "timestamp": "2026-03-18T10:00:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 2,
+  "fields": {
+    "white": 1,
+    "black": 4,
+    "result": "1-0",
+    "white_elo_before": 1200,
+    "black_elo_before": 1200,
+    "timestamp": "2026-03-19T14:30:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 3,
+  "fields": {
+    "white": 2,
+    "black": 5,
+    "result": "0-1",
+    "white_elo_before": 1215,
+    "black_elo_before": 1200,
+    "timestamp": "2026-03-20T09:15:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 4,
+  "fields": {
+    "white": 6,
+    "black": 3,
+    "result": "0-1",
+    "white_elo_before": 1200,
+    "black_elo_before": 1295,
+    "timestamp": "2026-03-21T16:00:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 5,
+  "fields": {
+    "white": 5,
+    "black": 1,
+    "result": "1-0",
+    "white_elo_before": 1220,
+    "black_elo_before": 1220,
+    "timestamp": "2026-03-22T11:45:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 6,
+  "fields": {
+    "white": 4,
+    "black": 6,
+    "result": "1/2-1/2",
+    "white_elo_before": 1185,
+    "black_elo_before": 1210,
+    "timestamp": "2026-03-23T08:30:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 7,
+  "fields": {
+    "white": 3,
+    "black": 5,
+    "result": "1-0",
+    "white_elo_before": 1300,
+    "black_elo_before": 1240,
+    "timestamp": "2026-03-24T15:20:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 8,
+  "fields": {
+    "white": 1,
+    "black": 6,
+    "result": "0-1",
+    "white_elo_before": 1230,
+    "black_elo_before": 1195,
+    "timestamp": "2026-03-25T13:00:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 9,
+  "fields": {
+    "white": 2,
+    "black": 4,
+    "result": "1-0",
+    "white_elo_before": 1175,
+    "black_elo_before": 1175,
+    "timestamp": "2026-03-26T10:10:00.000Z"
+  }
+},
+{
+  "model": "chessgame.chessmatch",
+  "pk": 10,
+  "fields": {
+    "white": 5,
+    "black": 6,
+    "result": "1-0",
+    "white_elo_before": 1255,
+    "black_elo_before": 1205,
+    "timestamp": "2026-03-27T17:45:00.000Z"
+  }
 }
 ]

--- a/backend/game/views.py
+++ b/backend/game/views.py
@@ -306,6 +306,23 @@ def player_profile(request, username):
         }
     except Player.DoesNotExist:
         pong_data = {'wins': 0, 'losses': 0, 'elo': 1000, 'total_games': 0}
+    
+    try:
+        pongAchievements = PlayerAchievement.objects.filter(player__user=user).select_related('achievement').order_by('-timestamp')[:5]
+        pong_achievements_data = {
+            'achievements': [
+                {
+                    'name': pa.achievement.name,
+                    'description': pa.achievement.description,
+                    'requirement_type': pa.achievement.requirement_type,
+                    'requirement_value': pa.achievement.requirement_value,
+                    'timestamp': pa.timestamp.isoformat()
+                }
+                for pa in pongAchievements
+            ]
+        }
+    except PlayerAchievement.DoesNotExist:
+        pong_achievements_data = {'achievements': []}
 
     try:
         chess = ChessPlayer.objects.get(user=user)
@@ -321,5 +338,6 @@ def player_profile(request, username):
     return JsonResponse({
         'username': user.username,
         'pong': pong_data,
+        # 'pong_achievements': pong_achievements_data['achievements'],
         'chess': chess_data,
     })

--- a/frontend/public/routes/profile.html
+++ b/frontend/public/routes/profile.html
@@ -106,7 +106,12 @@
             <button id="profile-stats"
                 class="w-full py-2 text-violet-400 font-semibold hover:text-white transition transform hover:scale-105"
                 data-i18n="PROFILE_STATISTICS">
-                Statistics
+                Statistics (Pong)
+            </button>
+
+            <button id="profile-chess-stats"
+                class="w-full py-2 text-violet-400 font-semibold hover:text-white transition transform hover:scale-105">
+                Statistics (Chess)
             </button>
 
             <button id="profile-logout"

--- a/frontend/public/routes/stats_chess.html
+++ b/frontend/public/routes/stats_chess.html
@@ -1,0 +1,71 @@
+<div class="min-h-screen flex justify-center items-start bg-zinc-900 py-12 px-4">
+  <div class="w-full max-w-3xl flex flex-col gap-6">
+
+    <div class="flex items-center gap-4">
+      <button id="stats-back-btn" class="text-zinc-400 hover:text-white transition text-sm">← Back</button>
+      <h1 class="text-white text-4xl font-bold">Statistics</h1>
+    </div>
+
+    <!-- Summary stats -->
+    <div class="bg-zinc-800 rounded-lg p-6 grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
+      <div>
+        <p class="text-zinc-400 text-sm mb-1">Total Games</p>
+        <p id="stats-total-games" class="text-white text-3xl font-bold">—</p>
+      </div>
+      <div>
+        <p class="text-zinc-400 text-sm mb-1">Wins</p>
+        <p id="stats-wins" class="text-green-400 text-3xl font-bold">—</p>
+      </div>
+      <div>
+        <p class="text-zinc-400 text-sm mb-1">Losses</p>
+        <p id="stats-losses" class="text-red-400 text-3xl font-bold">—</p>
+      </div>
+      <div>
+        <p class="text-zinc-400 text-sm mb-1">ELO</p>
+        <p id="stats-elo" class="text-violet-400 text-3xl font-bold">—</p>
+      </div>
+    </div>
+
+    <!-- Leaderboard -->
+    <div class="bg-zinc-800 rounded-lg p-6">
+      <p class="text-white font-semibold text-lg mb-3">🥇 Leaderboard</p>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="text-orange-400 text-xs uppercase border-b border-zinc-700">
+              <th class="text-left pb-2 pr-3">#</th>
+              <th class="text-left pb-2 pr-3">Player</th>
+              <th class="text-left pb-2 pr-3">ELO</th>
+              <th class="text-left pb-2 pr-3">Wins</th>
+              <th class="text-left pb-2">Games</th>
+            </tr>
+          </thead>
+          <tbody id="stats-leaderboard-table">
+            <tr><td colspan="5" class="text-zinc-500 pt-2">Loading...</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Match history -->
+    <div class="bg-zinc-800 rounded-lg p-6">
+      <p class="text-white font-semibold text-lg mb-3">🕹️ Match History</p>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="text-orange-400 text-xs uppercase border-b border-zinc-700">
+              <th class="text-left pb-2 pr-3">You</th>
+              <th class="text-left pb-2 pr-3">Opponent</th>
+              <th class="text-left pb-2 pr-3">Score</th>
+              <th class="text-left pb-2 pr-3">Result</th>
+              <th class="text-left pb-2">Date</th>
+            </tr>
+          </thead>
+          <tbody id="stats-history-table">
+            <tr><td colspan="4" class="text-zinc-500 pt-2">Loading...</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -366,6 +366,93 @@ export function setupRoutes() {
       .catch(() => {});
   };
 
+  routes['/chess-stats'] = async () => {
+    stopTournamentAutoRefresh();
+    if (await redirectIfNotLoggedIn())
+      return;
+
+    await loadTemplate('stats_chess');
+
+    document.getElementById('stats-back-btn')?.addEventListener('click', () => navigate('/profile'));
+
+    fetchWithRefreshAuth('/api/chess/stats/')
+      .then(r => r.json())
+      .then(data => {
+        const set = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = val ?? '-'; };
+        set('stats-total-games', data.total_games);
+        set('stats-wins', data.total_wins);
+        set('stats-losses', data.total_losses);
+        set('stats-elo', data.elo_rating);
+      })
+      .catch(() => {});
+
+    fetchWithRefreshAuth('/api/chess/leaderboard/')
+      .then(r => r.json())
+      .then(data => {
+        const tbody = document.getElementById('stats-leaderboard-table');
+        if (!tbody) return;
+        if (!data.leaderboard || data.leaderboard.length === 0) {
+          tbody.innerHTML = '<tr><td colspan="5" class="text-zinc-500 pt-2">No data yet.</td></tr>';
+          return;
+        }
+        tbody.innerHTML = data.leaderboard
+          .map((p, i) => {
+            const medal = i === 0 ? '#1' : i === 1 ? '#2' : i === 2 ? '#3' : `#${i + 1}`;
+            return `<tr class="border-t border-zinc-700">
+              <td class="py-1 pr-3">${medal}</td>
+              <td class="py-1 pr-3 font-semibold">${p.username}</td>
+              <td class="py-1 pr-3 text-violet-400">${p.elo_rating}</td>
+              <td class="py-1 pr-3 text-green-400">${p.total_wins}</td>
+              <td class="py-1 text-yellow-400">${p.total_games}</td>
+            </tr>`;
+          })
+          .join('');
+      })
+      .catch(() => {
+        const tbody = document.getElementById('stats-leaderboard-table');
+        if (tbody) tbody.innerHTML = '<tr><td colspan="5" class="text-zinc-500">Could not load.</td></tr>';
+      });
+
+    fetchWithRefreshAuth('/api/chess/match-history/')
+      .then(r => r.json())
+      .then(data => {
+        const tbody = document.getElementById('stats-history-table');
+        if (!tbody) return;
+        if (!data.matches || data.matches.length === 0) {
+          tbody.innerHTML = '<tr><td colspan="4" class="text-zinc-500 pt-2">No games yet.</td></tr>';
+          return;
+        }
+        tbody.innerHTML = data.matches
+          .map(m => {
+            const resultLabel = m.result === '1/2-1/2'
+              ? '<span class="text-zinc-400">Draw</span>'
+              : m.winner
+                ? (m.winner === m.opponent
+                    ? '<span class="text-red-400">Loss</span>'
+                    : '<span class="text-green-400">Win</span>')
+                : '<span class="text-zinc-400">-</span>';
+            const colorDot = (color) => color === 'White'
+              ? '<span class="inline-block w-4 h-4 rounded-sm bg-white border border-zinc-400"></span>'
+              : '<span class="inline-block w-4 h-4 rounded-sm bg-zinc-900 border border-zinc-500"></span>';
+            const yourColor = m.white === m.opponent ? 'Black' : 'White';
+            const opponentColor = m.white === m.opponent ? 'White' : 'Black';
+            const date = new Date(m.timestamp).toLocaleDateString();
+            return `<tr class="border-t border-zinc-700">
+              <td class="py-1 pr-3">${colorDot(yourColor)}</td>
+              <td class="py-1 pr-3 flex items-center gap-2">${colorDot(opponentColor)} ${m.opponent}</td>
+              <td class="py-1 pr-3 font-semibold">${m.result}</td>
+              <td class="py-1 pr-3">${resultLabel}</td>
+              <td class="py-1 text-zinc-400">${date}</td>
+            </tr>`;
+          })
+          .join('');
+      })
+      .catch(() => {
+        const tbody = document.getElementById('stats-history-table');
+        if (tbody) tbody.innerHTML = '<tr><td colspan="5" class="text-zinc-500">Could not load.</td></tr>';
+      });
+  };
+
   routes['/tournament/:tournamentId'] = async (tournamentId) => {
     stopTournamentAutoRefresh();
     if(await redirectIfNotLoggedIn())

--- a/frontend/src/users_friends/profilePage.js
+++ b/frontend/src/users_friends/profilePage.js
@@ -72,6 +72,7 @@ function setupLogoutButton(){
 
 function setupStatsNavButton(){
     document.getElementById("profile-stats")?.addEventListener("click", () => navigate("/stats"));
+    document.getElementById("profile-chess-stats")?.addEventListener("click", () => navigate("/chess-stats"));
 }
 
 function setupAddFriend(){


### PR DESCRIPTION
**Backend — Chess stats & history system**

backend/chessgame/consumers.py: When a game ends, now tracks wins/losses/total games on each player's ChessPlayer record and stores a result_str (e.g. "1-0", "0-1", "1/2-1/2") in the match.

backend/chessgame/models.py: Added a get_leaderboard() class method to ChessPlayer that returns the top 10 players ordered by ELO.

backend/chessgame/urls.py: Registered 3 new API endpoints: /chess/stats/, /chess/leaderboard/, /chess/match-history/.

backend/chessgame/views.py: Implemented those 3 new views — personal stats, global leaderboard (top 10), and last 20 match history for the logged-in user.

backend/fixtures/users.json: Added seed data — 6 ChessPlayer entries and 10 ChessMatch entries for testing.

**Frontend — Chess stats page**

frontend/public/routes/profile.html: Added a "Statistics (Chess)" button to the profile sidebar (renamed existing one to "Statistics (Pong)").

frontend/src/users_friends/profilePage.js: Wired the new chess stats button to navigate to /chess-stats.

frontend/src/routes/routes.js: Added the /chess-stats route — fetches and renders personal stats (ELO, wins, losses), leaderboard table, and match history table.

frontend/public/routes/stats_chess.html (new, untracked): The HTML template for the chess stats page.