### PR TITLE
feat(chat): game invites, seen receipts, typing indicator, and polish

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -209,7 +209,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			if not target or not game_type or not game_id:
 				logger.warning(f"[invite] missing fields — target={target} game_type={game_type} game_id={game_id}")
 				return
-			if target in IN_GAME_USERS:
+			if target in IN_GAME_USERS or self.user_id in IN_GAME_USERS:
 				await self.send(text_data=json.dumps({
 					"type": "game_invite_rejected",
 					"reason": "in_game",
@@ -310,11 +310,14 @@ class ChatConsumer(AsyncWebsocketConsumer):
 	async def game_result(self, event):
 		winner = event.get("winner")
 		loser = event.get("loser")
+		draw_players = event.get("draw_players")
 		game_type = event.get("game_type", "game")
 		if winner and loser:
 			msg = f"{winner} beat {loser} in a game of {game_type}!"
 		elif winner:
 			msg = f"{winner} won a game of {game_type}!"
+		elif draw_players and all(draw_players):
+			msg = f"{draw_players[0]} and {draw_players[1]} drew in a game of {game_type}!"
 		else:
 			msg = f"A game of {game_type} ended in a draw."
 		await self.send(text_data=json.dumps({

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -78,7 +78,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		# Deliver any game result the user missed while their chat WS was down.
 		pending = PENDING_GAME_RESULTS.pop(self.user_id, None)
 		if pending:
-			await self.send(text_data=json.dumps(pending))
+			await self.send(text_data=json.dumps({
+				"type": "game_result",
+				"message": self.format_game_result_message(pending),
+			}))
 
 		# Broadcast updated online users list to everyone.
 		await self.broadcast_online_users()
@@ -307,22 +310,24 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			"game_id": event["game_id"],
 		}))
 
-	async def game_result(self, event):
+	def format_game_result_message(self, event):
 		winner = event.get("winner")
 		loser = event.get("loser")
 		draw_players = event.get("draw_players")
 		game_type = event.get("game_type", "game")
 		if winner and loser:
-			msg = f"{winner} beat {loser} in a game of {game_type}!"
+			return f"{winner} beat {loser} in a game of {game_type}!"
 		elif winner:
-			msg = f"{winner} won a game of {game_type}!"
+			return f"{winner} won a game of {game_type}!"
 		elif draw_players and all(draw_players):
-			msg = f"{draw_players[0]} and {draw_players[1]} drew in a game of {game_type}!"
+			return f"{draw_players[0]} and {draw_players[1]} drew in a game of {game_type}!"
 		else:
-			msg = f"A game of {game_type} ended in a draw."
+			return f"A game of {game_type} ended in a draw."
+
+	async def game_result(self, event):
 		await self.send(text_data=json.dumps({
 			"type": "game_result",
-			"message": msg,
+			"message": self.format_game_result_message(event),
 		}))
 
 	async def trigger_online_users_broadcast(self, event):

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -14,6 +14,7 @@ ONLINE_USERS = {}          # user_id -> username
 USER_CONNECTION_COUNT = {}  # user_id -> number of open tabs; reaches 0 when last tab closes
 ACTIVE_CONVERSATION = {}   # user_id -> other_user_id they currently have open
 IN_GAME_USERS = set()      # user_ids currently in an active game (any game type)
+PENDING_GAME_RESULTS = {}  # user_id -> game result message to deliver on next reconnect
 # unread_count and is_closed are stored in ConversationParticipant in the database.
 # ACTIVE_CONVERSATION stays in-memory: it reflects the live UI state and resets
 # naturally when the user reconnects.
@@ -73,6 +74,11 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			"user_id": self.user_id,
 			"name": self.username
 		}))
+
+		# Deliver any game result the user missed while their chat WS was down.
+		pending = PENDING_GAME_RESULTS.pop(self.user_id, None)
+		if pending:
+			await self.send(text_data=json.dumps(pending))
 
 		# Broadcast updated online users list to everyone.
 		await self.broadcast_online_users()

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -249,6 +249,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
 						"type": "game.invite.accepted",
 						"game_id": game_id,
 					})
+					await self.channel_layer.group_send(f"user_{self.user_id}", {
+						"type": "game.invite.accepted",
+						"game_id": game_id,
+					})
 
 		elif msg_type == "user_blocked":
 			target = data.get("target")

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -263,13 +263,16 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			await self.broadcast_online_users()
 
 		elif msg_type in ["typing", "stop_typing"]:
+			target = data.get("target")
+			group = f"user_{target}" if target else self.group_name
 			await self.channel_layer.group_send(
-				self.group_name,
+				group,
 				{
 					"type": "typing.notification",
 					"action": msg_type,
 					"user": self.user_id,
 					"name": self.username,
+					"target": target,
 				}
 			)
 
@@ -350,7 +353,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		await self.send(text_data=json.dumps({
 			"type": event["action"],  # "typing" or "stop_typing"
 			"user": event["user"],
-			"name": event.get("name")
+			"name": event.get("name"),
+			"target": event.get("target"),
 		}))
 
 	async def online_users(self, event):

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -154,11 +154,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			other_id = data.get("target")
 			if not other_id:
 				return
-			messages = await self.get_dm_history(self.user_id, other_id)
+			messages, seen = await self.get_dm_history(self.user_id, other_id)
 			await self.send(text_data=json.dumps({
 				"type": "dm_history",
 				"target": other_id,
-				"messages": messages
+				"messages": messages,
+				"seen": seen,
 			}))
 
 		elif msg_type == "get_conversations":
@@ -187,6 +188,11 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			logger.info(f"[mark_read] user={self.username}({self.user_id}) read conversation with {other_id}")
 			# Reset the unread counter for this conversation in the database.
 			await self.mark_read(self.user_id, other_id)
+			# Notify the other user that their messages were read.
+			await self.channel_layer.group_send(
+				f"user_{other_id}",
+				{"type": "messages.read", "by": self.user_id}
+			)
 
 		elif msg_type == "close_conversation":
 			other_id = data.get("target")
@@ -281,6 +287,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			"name": event.get("name"),
 			"private": event.get("private", False),  # True for DMs, False for global
 			"target": event.get("target")             # user_id of DM recipient, or None for global
+		}))
+
+	async def messages_read(self, event):
+		await self.send(text_data=json.dumps({
+			"type": "messages_read",
+			"by": event["by"],
 		}))
 
 	async def game_invite(self, event):
@@ -415,7 +427,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		).values_list('conversation_id', flat=True).first()
 
 		if not shared_conv_id:
-			return []
+			return [], False
 
 		# Fetch the 50 most recent messages, then reverse so they're oldest-first.
 		messages = Message.objects.filter(
@@ -448,7 +460,25 @@ class ChatConsumer(AsyncWebsocketConsumer):
 				"created_at": inv.created_at.isoformat()
 			})
 
-		return result
+		# "Seen" = the other participant has read at or after the last message's timestamp.
+		seen = False
+		last_msg_ts = None
+		if result:
+			for item in reversed(result):
+				if item.get("sender_id") == user_id:
+					last_msg_ts = item.get("created_at")
+					break
+		if last_msg_ts:
+			other_part = ConversationParticipant.objects.filter(
+				conversation_id=shared_conv_id,
+				user_id=other_id
+			).values_list('last_read_at', flat=True).first()
+			from django.utils.dateparse import parse_datetime
+			ts = parse_datetime(last_msg_ts)
+			if other_part and ts and other_part >= ts:
+				seen = True
+
+		return result, seen
 
 	def _get_or_create_conversation(self, recipient_id):
 		from chat.models import Conversation, ConversationParticipant
@@ -538,9 +568,20 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			).exclude(user_id=user_id).select_related('user').first()
 
 			if other_part:
+				# "Seen" = the other participant has read at or after our last sent message.
+				# We need the last message sent by user_id in this conversation.
+				from chat.models import Message
+				last_sent = Message.objects.filter(
+					conversation=my_part.conversation,
+					sender_id=user_id
+				).order_by('-created_at').values_list('created_at', flat=True).first()
+				seen = False
+				if last_sent and other_part.last_read_at and other_part.last_read_at >= last_sent:
+					seen = True
 				result[str(other_part.user_id)] = {
 					"name": other_part.user.username,
-					"unread": my_part.unread_count
+					"unread": my_part.unread_count,
+					"seen": seen,
 				}
 
 		return result
@@ -560,10 +601,11 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		).values_list('conversation_id', flat=True).first()
 
 		if shared_conv_id:
+			from django.utils import timezone
 			ConversationParticipant.objects.filter(
 				conversation_id=shared_conv_id,
 				user_id=user_id
-			).update(unread_count=0)
+			).update(unread_count=0, last_read_at=timezone.now())
 
 	@database_sync_to_async
 	def close_conversation(self, user_id, other_id):

--- a/backend/chat/migrations/0001_initial.py
+++ b/backend/chat/migrations/0001_initial.py
@@ -43,6 +43,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('unread_count', models.IntegerField(default=0)),
                 ('is_closed', models.BooleanField(default=False)),
+                ('last_read_at', models.DateTimeField(blank=True, null=True)),
                 ('conversation', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='participants', to='chat.conversation')),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='conversations', to=settings.AUTH_USER_MODEL)),
             ],

--- a/backend/chat/models.py
+++ b/backend/chat/models.py
@@ -37,6 +37,10 @@ class ConversationParticipant(models.Model):
 	# Set back to False when a new message arrives.
 	is_closed = models.BooleanField(default=False)
 
+	# Set to now() whenever this user reads the conversation (mark_read).
+	# Used to compute whether the other user has seen the last message.
+	last_read_at = models.DateTimeField(null=True, blank=True)
+
 	def __str__(self):
 		return f"{self.user.username} in conversation {self.conversation_id}"
 

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -4,7 +4,7 @@ from channels.generic.websocket import AsyncWebsocketConsumer
 from asgiref.sync import sync_to_async
 from .models import ChessPlayer, ChessMatch
 from .models import ChessSession
-from chat.consumers import IN_GAME_USERS
+from chat.consumers import IN_GAME_USERS, PENDING_GAME_RESULTS
 
 logger = logging.getLogger(__name__)
 
@@ -99,13 +99,18 @@ class ChessConsumer(AsyncWebsocketConsumer):
 				loser_color = 'black' if winner == 'white' else 'white'
 				winner_name = getattr(self.game.players[winner], 'username', winner)
 				loser_name = getattr(self.game.players[loser_color], 'username', None)
-				await self.channel_layer.group_send('global_chat', {
+				result_msg = {
 					'type': 'game_result',
 					'winner': winner_name,
 					'loser': loser_name,
 					'game_type': 'chess',
-					'is_tournament': False
-				})
+					'is_tournament': False,
+				}
+				await self.channel_layer.group_send('global_chat', result_msg)
+				# Store for the abandoning player — their chat WS closed with the tab,
+				# so the global_chat broadcast won't reach them. Deliver on reconnect.
+				loser_id = str(self.game.players[self.color].id)
+				PENDING_GAME_RESULTS[loser_id] = result_msg
 
 			elif self.game.status == 'waiting' and self.game.invitee_id is not None:
 				invitor_id = str(self.game.players[self.color].id)

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -172,10 +172,13 @@ class ChessConsumer(AsyncWebsocketConsumer):
 			else:
 				winner_name = None
 				loser_name = None
+				white_name = getattr(self.game.players.get('white'), 'username', None)
+				black_name = getattr(self.game.players.get('black'), 'username', None)
 			await self.channel_layer.group_send('global_chat', {
 				'type': 'game_result',
 				'winner': winner_name,
 				'loser': loser_name,
+				'draw_players': [white_name, black_name] if not winner_name else None,
 				'game_type': 'chess',
 				'is_tournament': False
 			})

--- a/backend/fixtures/users.json
+++ b/backend/fixtures/users.json
@@ -112,7 +112,7 @@
   "pk": 1,
   "fields": {
     "user": 1,
-    "avatar": "",
+    "avatar": ""
   }
 },
 {
@@ -120,7 +120,7 @@
   "pk": 2,
   "fields": {
     "user": 2,
-    "avatar": "",
+    "avatar": ""
   }
 },
 {
@@ -128,7 +128,7 @@
   "pk": 3,
   "fields": {
     "user": 3,
-    "avatar": "",
+    "avatar": ""
   }
 },
 {
@@ -136,7 +136,7 @@
   "pk": 4,
   "fields": {
     "user": 4,
-    "avatar": "",
+    "avatar": ""
   }
 },
 {
@@ -144,7 +144,7 @@
   "pk": 5,
   "fields": {
     "user": 5,
-    "avatar": "",
+    "avatar": ""
   }
 },
 {
@@ -152,7 +152,7 @@
   "pk": 6,
   "fields": {
     "user": 6,
-    "avatar": "",
+    "avatar": ""
   }
 },
 {
@@ -605,5 +605,55 @@
     "achievement": 5,
     "timestamp": "2026-03-22T10:15:34.123Z"
   }
+},
+{
+  "model": "friends.friendrequest",
+  "pk": 1,
+  "fields": { "from_user": 1, "to_user": 2, "status": "accepted", "created_at": "2026-03-01T10:00:00Z", "updated_at": "2026-03-01T10:00:00Z" }
+},
+{
+  "model": "friends.friendrequest",
+  "pk": 2,
+  "fields": { "from_user": 1, "to_user": 3, "status": "accepted", "created_at": "2026-03-01T10:01:00Z", "updated_at": "2026-03-01T10:01:00Z" }
+},
+{
+  "model": "friends.friendrequest",
+  "pk": 3,
+  "fields": { "from_user": 1, "to_user": 4, "status": "accepted", "created_at": "2026-03-01T10:02:00Z", "updated_at": "2026-03-01T10:02:00Z" }
+},
+{
+  "model": "friends.friendrequest",
+  "pk": 4,
+  "fields": { "from_user": 1, "to_user": 5, "status": "accepted", "created_at": "2026-03-01T10:03:00Z", "updated_at": "2026-03-01T10:03:00Z" }
+},
+{
+  "model": "friends.friendrequest",
+  "pk": 5,
+  "fields": { "from_user": 4, "to_user": 3, "status": "accepted", "created_at": "2026-03-01T10:04:00Z", "updated_at": "2026-03-01T10:04:00Z" }
+},
+{
+  "model": "friends.block",
+  "pk": 1,
+  "fields": { "blocker": 6, "blocked_user": 1, "created_at": "2026-03-02T10:00:00Z" }
+},
+{
+  "model": "friends.block",
+  "pk": 2,
+  "fields": { "blocker": 6, "blocked_user": 2, "created_at": "2026-03-02T10:01:00Z" }
+},
+{
+  "model": "friends.block",
+  "pk": 3,
+  "fields": { "blocker": 6, "blocked_user": 3, "created_at": "2026-03-02T10:02:00Z" }
+},
+{
+  "model": "friends.block",
+  "pk": 4,
+  "fields": { "blocker": 6, "blocked_user": 4, "created_at": "2026-03-02T10:03:00Z" }
+},
+{
+  "model": "friends.block",
+  "pk": 5,
+  "fields": { "blocker": 6, "blocked_user": 5, "created_at": "2026-03-02T10:04:00Z" }
 }
 ]

--- a/backend/fixtures/users.json
+++ b/backend/fixtures/users.json
@@ -113,7 +113,6 @@
   "fields": {
     "user": 1,
     "avatar": "",
-    "bio": "Chat developer"
   }
 },
 {
@@ -122,7 +121,6 @@
   "fields": {
     "user": 2,
     "avatar": "",
-    "bio": "Game and auth developer"
   }
 },
 {
@@ -131,7 +129,6 @@
   "fields": {
     "user": 3,
     "avatar": "",
-    "bio": "Friends and chess developer"
   }
 },
 {
@@ -140,7 +137,6 @@
   "fields": {
     "user": 4,
     "avatar": "",
-    "bio": "Frontend developer"
   }
 },
 {
@@ -149,7 +145,6 @@
   "fields": {
     "user": 5,
     "avatar": "",
-    "bio": "Stats developer"
   }
 },
 {
@@ -158,7 +153,6 @@
   "fields": {
     "user": 6,
     "avatar": "",
-    "bio": "Servers maintainer in AlasCode"
   }
 },
 {

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -8,7 +8,7 @@ from channels.db import database_sync_to_async
 from .models import GameSession, Player
 from .services import match_ends
 import logging
-from chat.consumers import IN_GAME_USERS
+from chat.consumers import IN_GAME_USERS, PENDING_GAME_RESULTS
 
 logger = logging.getLogger(__name__)
 
@@ -322,16 +322,17 @@ class GameConsumer(AsyncWebsocketConsumer):
                     }
                 )
                 loser_name = getattr(departing_user, 'username', None)
-                await self.channel_layer.group_send(
-                    "global_chat",
-                    {
-                        "type": "game_result",
-                        "winner": winner_name,
-                        "loser": loser_name,
-                        "game_type": "pong",
-                        "is_tournament": self.game.isTournamentGame
-                    }
-                )
+                result_msg = {
+                    "type": "game_result",
+                    "winner": winner_name,
+                    "loser": loser_name,
+                    "game_type": "pong",
+                    "is_tournament": self.game.isTournamentGame
+                }
+                await self.channel_layer.group_send("global_chat", result_msg)
+                for pid in [str(winner_id), str(getattr(departing_user, 'id', None))]:
+                    if pid:
+                        PENDING_GAME_RESULTS[pid] = result_msg
 
             elif status_before == 'waiting' and getattr(self.game, 'invitee_id', None) is not None:
                 invitor_id = str(getattr(departing_user, 'id', None))
@@ -356,15 +357,6 @@ class GameConsumer(AsyncWebsocketConsumer):
                         'type': 'game_over',
                         'winner': 'Player disconnected',
                         'winner_id': None
-                    }
-                )
-                await self.channel_layer.group_send(
-                    "global_chat",
-                    {
-                        "type": "game_result",
-                        "winner": None,
-                        "game_type": "pong",
-                        "is_tournament": self.game.isTournamentGame
                     }
                 )
 
@@ -441,16 +433,17 @@ class GameConsumer(AsyncWebsocketConsumer):
                             'new_achievements': new_achievements,
                         }
                     )
-                    await self.channel_layer.group_send(
-                        'global_chat',
-                        {
-                            'type': 'game_result',
-                            'winner': winner_name,
-                            'loser': loser_name,
-                            'game_type': 'pong',
-                            'is_tournament': self.game.isTournamentGame,
-                        }
-                    )
+                    result_msg = {
+                        'type': 'game_result',
+                        'winner': winner_name,
+                        'loser': loser_name,
+                        'game_type': 'pong',
+                        'is_tournament': self.game.isTournamentGame,
+                    }
+                    await self.channel_layer.group_send('global_chat', result_msg)
+                    for pid in [str(winner_id), str(getattr(loser_user, 'id', None))]:
+                        if pid:
+                            PENDING_GAME_RESULTS[pid] = result_msg
                     break
             
             await asyncio.sleep(1/60)  # 60 FPS

--- a/backend/profiles/migrations/0001_initial.py
+++ b/backend/profiles/migrations/0001_initial.py
@@ -19,7 +19,6 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('avatar', models.URLField(blank=True)),
-                ('bio', models.TextField(blank=True)),
                 ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='profile', to=settings.AUTH_USER_MODEL)),
             ],
             options={

--- a/backend/profiles/models.py
+++ b/backend/profiles/models.py
@@ -8,7 +8,6 @@ class UserProfile(models.Model):
 	# related_name='profile' adds a shortcut going the other direction, we can now write some_user.profile
 	user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
 	avatar = models.URLField(blank=True)  # URL to profile picture, empty by default
-	bio = models.TextField(blank=True)    # free text bio, empty by default
 	
 	# defines how the object looks when printed or displayed as a string 
 	# Without it, printing a UserProfile object would show something unhelpful

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ services:
   backend:
     build: ./backend
     container_name: pong_backend
-    volumes:
-      # DEV ONLY: remove this mount in production - code should be baked into the image via COPY . . in Dockerfile
-      - ./backend:/app
     environment:
       - DJANGO_SETTINGS_MODULE=django_server.settings
       - DEBUG=True

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,6 +64,7 @@
 					# Global Chat
 				</div>
 				<div id="chatMessages" class="flex-1 overflow-y-auto p-4 flex flex-col gap-2"></div>
+				<div id="typingIndicator" class="px-4 h-5 flex-shrink-0 text-sm text-gray-300 italic"></div>
 				<div id="chatInputWrapper" class="p-4 bg-black/80 border-t border-pink-600/30 flex-shrink-0">
 					<textarea id="chatInput" rows="2" placeholder="Type a message..."
 						class="w-full px-3 py-2 bg-gray-800 text-white rounded resize-none 

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -155,7 +155,8 @@ export function initChatUI() {
 			renderMessages(channelId);
 			// If it's a DM from someone else, mark it read — but only if the chat window is actually visible
 			if (channelId !== "global" && message.senderId !== verifiedUserId
-					&& chatContainer?.style.display !== "none") {
+					&& chatContainer?.style.display !== "none"
+					&& document.visibilityState === "visible") {
 				markRead(channelId);
 			}
 		} else if (message.senderId !== verifiedUserId) {

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -337,6 +337,11 @@ export function initChatUI() {
 					e.stopPropagation();
 					showChatUserMenu({ id, name }, e.clientX, e.clientY);
 				});
+				div.addEventListener("dblclick", (e) => {
+					e.stopPropagation();
+					hideChatUserMenu();
+					openDMChannel(id, name || id);
+				});
 			}
 
 			onlineUsersList.appendChild(div);

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -224,11 +224,13 @@ export function initChatUI() {
 		// Scroll to bottom so latest message is always visible
 		chatMessages.scrollTop = chatMessages.scrollHeight;
 
-		// Clear unread badge when switching to this channel
-		const tab = document.querySelector(`[data-channel="${channelId}"]`);
-		if (tab) {
-			const badge = tab.querySelector(".unread-badge");
-			if (badge) badge.remove();
+		// Clear unread badge only when the user is actively viewing this channel
+		if (channelId === activeChannel) {
+			const tab = document.querySelector(`[data-channel="${channelId}"]`);
+			if (tab) {
+				const badge = tab.querySelector(".unread-badge");
+				if (badge) badge.remove();
+			}
 		}
 	}
 
@@ -559,8 +561,24 @@ export function initChatUI() {
 	function removeInviteFromHistory(gameId) {
 		for (const channelId in messageHistory) {
 			const before = messageHistory[channelId].length;
+			const removedFromOther = messageHistory[channelId].filter(
+				m => m.invite?.gameId === gameId && m.senderId !== verifiedUserId
+			).length;
 			messageHistory[channelId] = messageHistory[channelId].filter(m => m.invite?.gameId !== gameId);
-			if (messageHistory[channelId].length < before) renderMessages(channelId);
+			if (messageHistory[channelId].length < before) {
+				renderMessages(channelId);
+				if (channelId !== activeChannel && removedFromOther > 0) {
+					const tab = document.querySelector(`[data-channel="${channelId}"]`);
+					if (tab) {
+						const badge = tab.querySelector(".unread-badge");
+						if (badge) {
+							const newCount = parseInt(badge.textContent) - removedFromOther;
+							if (newCount <= 0) badge.remove();
+							else badge.textContent = newCount;
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -73,7 +73,8 @@ export function initChatUI() {
 		if (channelId === "global") {
 			channelTitle.textContent = "# Global Chat";
 		} else {
-			const name = onlineUsers[channelId]?.name;
+			const name = onlineUsers[channelId]?.name
+				|| activeTab?.querySelector("span:nth-child(2)")?.textContent;
 			channelTitle.textContent = name ? `@ ${name}` : "@ Direct Message";
 			markRead(channelId);
 		}

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -443,7 +443,8 @@ export function initChatUI() {
 		const inviteBtn = chatUserMenu.querySelector('[data-action="invite"]');
 		if (inviteBtn) {
 			const targetInGame = onlineUsers[user.id]?.in_game;
-			inviteBtn.style.display = (targetInGame || pendingInvite) ? "none" : "";
+			const senderInGame = onlineUsers[verifiedUserId]?.in_game;
+			inviteBtn.style.display = (targetInGame || senderInGame || pendingInvite) ? "none" : "";
 		}
 
 		// Position at cursor - nudge left/up if too close to screen edge

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -153,8 +153,9 @@ export function initChatUI() {
 		if (channelId === activeChannel) {
 			// User is already viewing this channel, render immediately
 			renderMessages(channelId);
-			// If it's a DM from someone else, mark it read immediately since we're already here
-			if (channelId !== "global" && message.senderId !== verifiedUserId) {
+			// If it's a DM from someone else, mark it read — but only if the chat window is actually visible
+			if (channelId !== "global" && message.senderId !== verifiedUserId
+					&& chatContainer?.style.display !== "none") {
 				markRead(channelId);
 			}
 		} else if (message.senderId !== verifiedUserId) {

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -25,8 +25,9 @@ export function initChatUI() {
 	// activeChannel is either "global" or a user ID for DMs
 	let activeChannel = "global";
 	// messageHistory stores messages per channel — keyed by "global" or user ID
-	// Messages are lost on refresh since there's no database yet
 	const messageHistory = { global: [] };
+	// tracks which DM channels have been read by the other person
+	const seenBy = {}; // channelId -> true/false
 
 	// ── Channel management ────────────────────────────────────────────────────
 
@@ -147,6 +148,10 @@ export function initChatUI() {
 		if (channelId === activeChannel) {
 			// User is already viewing this channel, render immediately
 			renderMessages(channelId);
+			// If it's a DM from someone else, mark it read immediately since we're already here
+			if (channelId !== "global" && message.senderId !== verifiedUserId) {
+				markRead(channelId);
+			}
 		} else if (message.senderId !== verifiedUserId) {
 			// Only badge for messages from others — own messages echoed to other tabs shouldn't count as unread
 			const tab = document.querySelector(`[data-channel="${channelId}"]`);
@@ -220,6 +225,15 @@ export function initChatUI() {
 			msgDiv.appendChild(messageSpan);
 			chatMessages.appendChild(msgDiv);
 		});
+
+		// Show "Seen" only if the other person read AND the last message is ours
+		const lastMsg = messages[messages.length - 1];
+		if (channelId !== "global" && seenBy[channelId] && lastMsg?.senderId === verifiedUserId) {
+			const seenDiv = document.createElement("div");
+			seenDiv.className = "text-right text-xs text-gray-400 pr-1 mt-1 font-medium";
+			seenDiv.textContent = "✓ Seen";
+			chatMessages.appendChild(seenDiv);
+		}
 
 		// Scroll to bottom so latest message is always visible
 		chatMessages.scrollTop = chatMessages.scrollHeight;
@@ -317,7 +331,7 @@ export function initChatUI() {
 
 	// chat.js dispatches this when DM history is fetched from the database
 	window.addEventListener("dmHistoryReceived", (e) => {
-		const { channelId, messages } = e.detail;
+		const { channelId, messages, seen } = e.detail;
 		if (!messageHistory[channelId]) messageHistory[channelId] = [];
 		messageHistory[channelId] = messages.map(msg => {
 			const entry = {
@@ -331,6 +345,7 @@ export function initChatUI() {
 			}
 			return entry;
 		});
+		if (seen) seenBy[channelId] = true;
 		if (channelId === activeChannel) renderMessages(channelId);
 	});
 	
@@ -348,6 +363,7 @@ export function initChatUI() {
 					tab.appendChild(badge);
 				}
 			}
+			if (data.seen) seenBy[userId] = true;
 		});
 	});
 	
@@ -582,6 +598,12 @@ export function initChatUI() {
 		}
 	}
 
+	window.addEventListener("messagesRead", (e) => {
+		const channelId = e.detail.by;
+		seenBy[channelId] = true;
+		if (activeChannel === channelId) renderMessages(channelId);
+	});
+
 	window.addEventListener("gameInviteAccepted", (e) => removeInviteFromHistory(e.detail.gameId));
 	window.addEventListener("gameInviteExpired", (e) => removeInviteFromHistory(e.detail.gameId));
 	window.addEventListener("gameInviteBlocked", (e) => {
@@ -626,6 +648,8 @@ export function initChatUI() {
 
 			// null target means global chat, otherwise it's a DM to that user ID
 			const target = activeChannel === "global" ? null : activeChannel;
+			// Clear "Seen" when we send a new message — it's no longer valid
+			if (target) seenBy[target] = false;
 			sendChatMessage(message, target);
 
 			chatInput.value = "";

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -20,6 +20,7 @@ export function initChatUI() {
 	const chatMessages = document.getElementById("chatMessages");
 	const channelTitle = document.getElementById("channelTitle");
 	const blockNotice = document.getElementById("blockNotice");
+	const typingIndicator = document.getElementById("typingIndicator");
 
 	// ── State ─────────────────────────────────────────────────────────────────
 	// activeChannel is either "global" or a user ID for DMs
@@ -28,6 +29,8 @@ export function initChatUI() {
 	const messageHistory = { global: [] };
 	// tracks which DM channels have been read by the other person
 	const seenBy = {}; // channelId -> true/false
+	// tracks who is currently typing per channel: channelId -> Map(userId -> name)
+	const typingUsers = {};
 
 	// ── Channel management ────────────────────────────────────────────────────
 
@@ -82,6 +85,7 @@ export function initChatUI() {
 		}
 
 		renderMessages(channelId);
+		renderTypingIndicator();
 		updateDMInputState(channelId);
 		document.getElementById("chatInput").focus();
 	}
@@ -247,6 +251,37 @@ export function initChatUI() {
 			}
 		}
 	}
+
+	// ── Typing indicator ─────────────────────────────────────────────────────
+
+	function renderTypingIndicator() {
+		if (!typingIndicator) return;
+		const typers = typingUsers[activeChannel];
+		if (!typers || typers.size === 0) {
+			typingIndicator.textContent = "";
+			return;
+		}
+		if (typers.size === 1) {
+			const name = [...typers.values()][0];
+			typingIndicator.textContent = `${name} is typing...`;
+		} else {
+			typingIndicator.textContent = `${typers.size} people are typing...`;
+		}
+	}
+
+	window.addEventListener("typingStarted", (e) => {
+		const { userId, name, channelId } = e.detail;
+		if (userId === verifiedUserId) return;
+		if (!typingUsers[channelId]) typingUsers[channelId] = new Map();
+		typingUsers[channelId].set(userId, name);
+		if (channelId === activeChannel) renderTypingIndicator();
+	});
+
+	window.addEventListener("typingStopped", (e) => {
+		const { userId, channelId } = e.detail;
+		if (typingUsers[channelId]) typingUsers[channelId].delete(userId);
+		if (channelId === activeChannel) renderTypingIndicator();
+	});
 
 	// ── Online users ──────────────────────────────────────────────────────────
 
@@ -638,7 +673,8 @@ export function initChatUI() {
 	});
 
 	// initTyping attaches the typing indicator to the textarea (chat.js)
-	initTyping(chatInput);
+	// Pass a getTarget callback so typing events include the active DM channel
+	initTyping(chatInput, () => activeChannel === "global" ? null : activeChannel);
 
 	if (sendChatBtn && chatInput) {
 		const sendMessage = () => {

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -648,6 +648,14 @@ export function initChatUI() {
 		if (activeChannel === channelId) renderMessages(channelId);
 	});
 
+	document.addEventListener("visibilitychange", () => {
+		if (document.visibilityState === "visible"
+				&& activeChannel !== "global"
+				&& chatContainer?.style.display !== "none") {
+			markRead(activeChannel);
+		}
+	});
+
 	window.addEventListener("gameInviteAccepted", (e) => removeInviteFromHistory(e.detail.gameId));
 	window.addEventListener("gameInviteExpired", (e) => {
 		removeInviteFromHistory(e.detail.gameId);

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -643,7 +643,13 @@ export function initChatUI() {
 	});
 
 	window.addEventListener("gameInviteAccepted", (e) => removeInviteFromHistory(e.detail.gameId));
-	window.addEventListener("gameInviteExpired", (e) => removeInviteFromHistory(e.detail.gameId));
+	window.addEventListener("gameInviteExpired", (e) => {
+		removeInviteFromHistory(e.detail.gameId);
+		if (pendingInvite) {
+			pendingInvite = false;
+			window.history.back();
+		}
+	});
 	window.addEventListener("gameInviteBlocked", (e) => {
 		removeInviteFromHistory(e.detail.gameId);
 		if (pendingInvite) {

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -419,6 +419,7 @@ export function initChatUI() {
 			openChatBtn.style.display = "none";
 			chatInput.focus();
 			renderOnlineUsers();
+			if (activeChannel !== "global") markRead(activeChannel);
 		});
 	}
 

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -104,7 +104,8 @@ export function initChat() {
 				window.dispatchEvent(new CustomEvent("dmHistoryReceived", {
 					detail: {
 						channelId: data.target,
-						messages: data.messages
+						messages: data.messages,
+						seen: data.seen,
 					}
 				}));
 				break;
@@ -113,6 +114,12 @@ export function initChat() {
 				console.log("conversations received:", data.conversations);
 				window.dispatchEvent(new CustomEvent("conversationsReceived", {
 					detail: { conversations: data.conversations }
+				}));
+				break;
+
+			case "messages_read":
+				window.dispatchEvent(new CustomEvent("messagesRead", {
+					detail: { by: data.by }
 				}));
 				break;
 

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -171,17 +171,20 @@ export function initChat() {
 				}));
 				break;
 
-			// Another user started typing — show indicator (TODO in UI)
-			case "typing":
-				console.log(`${data.name || data.user} is typing...`);
-				// TODO: dispatch "typingStarted" event and show indicator in UI
+			case "typing": {
+				const channelId = data.target ? data.user : "global";
+				window.dispatchEvent(new CustomEvent("typingStarted", {
+					detail: { userId: data.user, name: data.name, channelId }
+				}));
 				break;
-
-			// Another user stopped typing
-			case "stop_typing":
-				console.log(`${data.name || data.user} stopped typing`);
-				// TODO: dispatch "typingStopped" event and hide indicator in UI
+			}
+			case "stop_typing": {
+				const channelId = data.target ? data.user : "global";
+				window.dispatchEvent(new CustomEvent("typingStopped", {
+					detail: { userId: data.user, channelId }
+				}));
 				break;
+			}
 
 			default:
 				console.warn("Unknown chat message type:", data.type);
@@ -217,8 +220,9 @@ export function sendChatMessage(message, target = null) {
  * Attach typing indicator events to the chat textarea.
  * Sends "typing" on input, then "stop_typing" after 1s of inactivity.
  * @param {HTMLTextAreaElement} chatInput - The textarea element.
+ * @param {Function} getTarget - Returns the current DM target user ID, or null for global.
  */
-export function initTyping(chatInput) {
+export function initTyping(chatInput, getTarget = () => null) {
 	if (!chatInput) {
 		console.warn("initTyping: no chatInput element provided");
 		return;
@@ -242,24 +246,19 @@ export function initTyping(chatInput) {
 			if (chatSocket.readyState !== WebSocket.OPEN) return;
 
 			// Tell the server this user is typing
-			chatSocket.send(JSON.stringify({
-				type: "typing",
-				user: verifiedUserId,
-				name: verifiedUserName,
-			}));
-			
+			const target = getTarget();
+			const typingPayload = { type: "typing", user: verifiedUserId, name: verifiedUserName };
+			if (target) typingPayload.target = target;
+			chatSocket.send(JSON.stringify(typingPayload));
+
 			// Debounce: cancel the previous countdown and start a fresh one
 			// "stop_typing" only fires if the user stops typing for a full second
 			clearTimeout(typingTimeout);
-			// We don't care about the actual value of typingTimeout
-			// we only store it so we can pass it to clearTimeout on the next keystroke
 			typingTimeout = setTimeout(() => {
 				if (chatSocket.readyState === WebSocket.OPEN) {
-					chatSocket.send(JSON.stringify({
-						type: "stop_typing",
-						user: verifiedUserId,
-						name: verifiedUserName
-					}));
+					const stopPayload = { type: "stop_typing", user: verifiedUserId, name: verifiedUserName };
+					if (target) stopPayload.target = target;
+					chatSocket.send(JSON.stringify(stopPayload));
 				}
 			}, 1000);
 		});

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -145,10 +145,9 @@ export function joinOnlineGame(gameId, IsTournament) {
   let keyUpHandler = null;
   let resizeHandler = null;
   let gameEnded = false;
-  
+
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
   ws = new WebSocket(`${proto}//${location.host}/ws/${gameId}`);
-
   ws.onopen = () => {
     console.log("WS connected to game:", gameId);
     isGameActive = true;
@@ -189,7 +188,6 @@ export function joinOnlineGame(gameId, IsTournament) {
         isGameActive = false;
         sessionStorage.removeItem('activeGameId');
         sessionStorage.removeItem('activeTournamentId');
-        window.dispatchEvent(new CustomEvent("pongGameLeft"));
         navigate('/');
     })
   };
@@ -286,7 +284,8 @@ export function joinOnlineGame(gameId, IsTournament) {
 
       if (data.type === "gameOver") {
         gameEnded = true;
-        
+        window.dispatchEvent(new CustomEvent("pongGameLeft"));
+
         // Remove waiting modal if it still exists
         const waitingModal = document.getElementById("waitingModal");
         if (waitingModal) {


### PR DESCRIPTION
- Game invites via DM: players can now invite each other to pong and chess directly from the DM chat window, mirroring the existing flow from the online users sidebar.  
- Missed game results: added PENDING_GAME_RESULTS server-side storage so players who refresh during a game still receive the result announcement on their next chat reconnect.
- Fixed false "draw" announcement: pong abandonment was incorrectly broadcasting a second game_result with no winner. Removed the spurious broadcast.                   
- Fixed unread badge on invite expiry: badge count now decrements correctly when a game invite expires rather than wiping the entire count.                             
- "✓ Seen" read receipts: DM messages now show a "✓ Seen" indicator when the other person has read your last message. State is persisted in the DB (last_read_at on ConversationParticipant) so it survives page refresh.     
- Live typing indicator: shows "[name] is typing..." in both global chat and DMs, routed correctly per channel.                                                        
- DM title fix for offline users: switching to a DM with an offline user now shows their name correctly instead of "@ Direct Message".                                  
- "Seen" false positive fix: markRead no longer fires when a message arrives in the active channel but the chat window is closed.                                        
- Cleanup: removed unused bio field from UserProfile (model + migration + fixture).
                                                                                       
Test plan:                                                                            
                                                                                       
- Invite a user to pong/chess from DM: invite appears, accept navigates to game     
- Invite expires while other user is offline: badge decrements correctly
- Player refreshes mid-pong-game: game result still appears in global chat on reconnect                                                                            
- Pong game abandoned: global chat shows winner/loser, not "draw"                   
- Chess/pong game ends normally: global chat shows correct result                   
- Send DMs: "✓ Seen" appears after other user reads, persists after refresh         
- Type in global chat and DM: typing indicator appears for the other user           
- Open DM with offline user: channel title shows their name                         
- Chat window closed, message arrives: sender does NOT see "✓ Seen"