### PR TITLE
feat(chat): add reject button to game invites

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -234,6 +234,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			game_id = data.get("game_id")
 			if not target or not game_id:
 				return
+			await self.delete_invite(game_id)
 			payload = {
 				"type": "game.invite.expired",
 				"game_id": game_id,

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -20,6 +20,11 @@ class ChessConsumer(AsyncWebsocketConsumer):
 			await self.close(code=4004)
 			return
 		
+		#reject if this user is already in another game
+		if str(self.scope['user'].id) in IN_GAME_USERS:
+			await self.close(code=4003)
+			return
+
 		#try to seat this connection as white or black
 		self.color = self.game.add_player(self.scope['user'])
 		if not self.color:
@@ -58,12 +63,11 @@ class ChessConsumer(AsyncWebsocketConsumer):
 				IN_GAME_USERS.add(pid)
 			await self.channel_layer.group_send('global_chat', {'type': 'trigger.online.users.broadcast'})
 
-			# Expire any pending invites between these two players so the
-			# Accept buttons disappear from both DM windows once the game starts.
-			if len(player_ids) == 2:
-				invite_ids = await self.get_invite_ids_between(player_ids[0], player_ids[1])
-				for gid in invite_ids:
-					for uid in player_ids:
+			# Expire all pending invites for each player so Accept buttons
+			# disappear everywhere — including invites from third parties.
+			for pid in player_ids:
+				for sender_id, gid in await self.get_pending_invites_for_recipient(pid):
+					for uid in [pid, str(sender_id)]:
 						await self.channel_layer.group_send(
 							f'user_{uid}',
 							{'type': 'game.invite.expired', 'game_id': gid}
@@ -213,20 +217,11 @@ class ChessConsumer(AsyncWebsocketConsumer):
 		}))
 
 	@sync_to_async
-	def get_invite_ids_between(self, user1_id, user2_id):
-		from chat.models import GameInvite, ConversationParticipant
-		conv_ids = ConversationParticipant.objects.filter(
-			user_id=user1_id
-		).values_list('conversation_id', flat=True)
-		shared_conv_id = ConversationParticipant.objects.filter(
-			conversation_id__in=conv_ids,
-			user_id=user2_id
-		).values_list('conversation_id', flat=True).first()
-		if not shared_conv_id:
-			return []
+	def get_pending_invites_for_recipient(self, user_id):
+		from chat.models import GameInvite
 		return list(GameInvite.objects.filter(
-			conversation_id=shared_conv_id
-		).values_list('game_id', flat=True))
+			recipient_id=user_id
+		).values_list('sender_id', 'game_id'))
 
 	async def save_chess_result(self, game, winner, result_str):
 		white_user = game.players['white']

--- a/backend/chessgame/views.py
+++ b/backend/chessgame/views.py
@@ -37,29 +37,31 @@ def join_chess(request):
 	if not user:
 		return JsonResponse({'error': 'Authentication required'}, status=401)
 
+	body = json.loads(request.body or '{}')
+	invitee_id = body.get('invitee_id')
+
 	#search and create are atomic so two players never both see an empty lobby
 	#colors are pre-assigned here so WS connect order does not cause a race
 	with ChessSession._lock:
-		for game in ChessSession._games.values():
-			if game.status == 'waiting':
-				white_id = getattr(game.players['white'], 'id', None)
-				black_id = getattr(game.players['black'], 'id', None)
-				#if only one slot is filled
-				if (white_id is None) != (black_id is None):
-					#if the slot is not filled by this user
-					if user.id not in (white_id, black_id):
-						if game.players['white'] is None:
-							game.players['white'] = user
-						else:
-							game.players['black'] = user
+		if not invitee_id:
+			for game in ChessSession._games.values():
+				if game.status == 'waiting' and game.invitee_id is None:
+					white_id = getattr(game.players['white'], 'id', None)
+					black_id = getattr(game.players['black'], 'id', None)
+					#if only one slot is filled
+					if (white_id is None) != (black_id is None):
+						#if the slot is not filled by this user
+						if user.id not in (white_id, black_id):
+							if game.players['white'] is None:
+								game.players['white'] = user
+							else:
+								game.players['black'] = user
 
-					return JsonResponse({'gameId': game.id})
+						return JsonResponse({'gameId': game.id})
 
 		game = ChessSession()
 		color = random.choice(['white', 'black'])
 		game.players[color] = user
-		body = json.loads(request.body or '{}')
-		invitee_id = body.get('invitee_id')
 		if invitee_id:
 			game.invitee_id = str(invitee_id)
 		ChessSession._games[game.id] = game

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -177,6 +177,11 @@ class GameConsumer(AsyncWebsocketConsumer):
         logger.debug(f"Headers: {headers}")
         logger.debug(f"Authorization: {headers.get(b'authorization')}")
 
+        # Reject if user is already in another game
+        if str(getattr(self.scope.get('user'), 'id', None)) in IN_GAME_USERS:
+            await self.close(code=4003)
+            return
+
         # Check for duplicate connections
         logger.debug(f"Scope: {self.scope}")
         logger.debug(f"Connecting to game: {self.game_id} with channel: {self.channel_name} and player {self.scope['user']}")
@@ -241,11 +246,10 @@ class GameConsumer(AsyncWebsocketConsumer):
                 IN_GAME_USERS.add(pid)
             await self.channel_layer.group_send('global_chat', {'type': 'trigger.online.users.broadcast'})
 
-            # Expire any pending invites between these two players
-            if len(player_ids) == 2:
-                invite_ids = await self.get_invite_ids_between(player_ids[0], player_ids[1])
-                for gid in invite_ids:
-                    for uid in player_ids:
+            # Expire all pending invites for each player, including from third parties
+            for pid in player_ids:
+                for sender_id, gid in await self.get_pending_invites_for_recipient(pid):
+                    for uid in [pid, str(sender_id)]:
                         await self.channel_layer.group_send(
                             f'user_{uid}',
                             {'type': 'game.invite.expired', 'game_id': gid}
@@ -543,18 +547,9 @@ class GameConsumer(AsyncWebsocketConsumer):
         """Close the websocket connection"""
         await self.close(code=1008)
 
-    @sync_to_async
-    def get_invite_ids_between(self, user1_id, user2_id):
-        from chat.models import GameInvite, ConversationParticipant
-        conv_ids = ConversationParticipant.objects.filter(
-            user_id=user1_id
-        ).values_list('conversation_id', flat=True)
-        shared_conv_id = ConversationParticipant.objects.filter(
-            conversation_id__in=conv_ids,
-            user_id=user2_id
-        ).values_list('conversation_id', flat=True).first()
-        if not shared_conv_id:
-            return []
+    @database_sync_to_async
+    def get_pending_invites_for_recipient(self, user_id):
+        from chat.models import GameInvite
         return list(GameInvite.objects.filter(
-            conversation_id=shared_conv_id
-        ).values_list('game_id', flat=True))
+            recipient_id=user_id
+        ).values_list('sender_id', 'game_id'))

--- a/backend/game/views.py
+++ b/backend/game/views.py
@@ -113,7 +113,7 @@ def join_pong(request):
         return error
     with GameSession._lock:
         for game in GameSession._games.values():
-            if game.status == 'waiting' and not game.isTournamentGame:
+            if game.status == 'waiting' and not game.isTournamentGame and game.invitee_id is None:
                 left_id = getattr(game.players['left'], 'id', None)
                 right_id = getattr(game.players['right'], 'id', None)
                 #if exactly one slot is filled

--- a/frontend/src/chat/chat-ui.js
+++ b/frontend/src/chat/chat-ui.js
@@ -223,6 +223,16 @@ export function initChatUI() {
 						}
 					});
 					msgDiv.appendChild(acceptBtn);
+					const rejectBtn = document.createElement("button");
+					rejectBtn.textContent = 'Reject';
+					rejectBtn.className = "ml-2 px-2 py-0.5 text-xs bg-gray-500 hover:bg-gray-400 rounded font-semibold";
+					rejectBtn.addEventListener("click", () => {
+						msgDiv.remove();
+						const idx = messageHistory[channelId].indexOf(msg);
+						if (idx !== -1) messageHistory[channelId].splice(idx, 1);
+						sendGameInviteExpired(msg.senderId, msg.invite.gameId);
+					});
+					msgDiv.appendChild(rejectBtn);
 				}
 				chatMessages.appendChild(msgDiv);
 				return;


### PR DESCRIPTION
Previously, an invitee had no way to decline a game invite. Only the inviter could cancel it. This meant a malicious user could send an invite and keep the recipient stuck, blocking any other player from inviting them.

Added a Reject button next to Accept on incoming invite cards. When clicked, the invite is removed from both sides and deleted from the DB. Translation key (CHAT_REJECT) to be added by Goksu