### PR TITLE
fix(chess): player names missing in draw broadcast + debug logging

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -119,6 +119,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
 		msg_type = data.get("type")
 
+		logger.debug(f"[receive] type={msg_type} user={self.username}({self.user_id})")
+
 		if msg_type == "chat":
 			message = data.get("message", "")
 			if len(message) > 300:
@@ -157,6 +159,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			other_id = data.get("target")
 			if not other_id:
 				return
+			logger.debug(f"[fetch_history] user={self.username}({self.user_id}) → target={other_id}")
 			messages, seen = await self.get_dm_history(self.user_id, other_id)
 			await self.send(text_data=json.dumps({
 				"type": "dm_history",
@@ -175,6 +178,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
 		elif msg_type == "open_conversation":
 			other_id = data.get("target")
+			logger.debug(f"[open_conversation] user={self.username}({self.user_id}) → target={other_id}")
 			if other_id:
 				# Track that this user is now actively viewing this DM tab.
 				# Used in save_dm to skip the unread increment for active viewers.
@@ -201,6 +205,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			other_id = data.get("target")
 			if not other_id:
 				return
+			logger.debug(f"[close_conversation] user={self.username}({self.user_id}) → target={other_id}")
 			# Mark this conversation as closed in the database.
 			await self.close_conversation(self.user_id, other_id)
 
@@ -234,6 +239,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			game_id = data.get("game_id")
 			if not target or not game_id:
 				return
+			logger.debug(f"[game_invite_expired] user={self.username}({self.user_id}) → target={target} game_id={game_id}")
 			await self.delete_invite(game_id)
 			payload = {
 				"type": "game.invite.expired",
@@ -243,6 +249,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
 		elif msg_type == "delete_invite":
 			game_id = data.get("game_id")
+			logger.debug(f"[delete_invite] user={self.username}({self.user_id}) game_id={game_id}")
 			if game_id:
 				sender_id = await self.delete_invite(game_id)
 				if sender_id:
@@ -257,6 +264,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
 		elif msg_type == "user_blocked":
 			target = data.get("target")
+			logger.debug(f"[user_blocked] user={self.username}({self.user_id}) → target={target}")
 			if target:
 				invite_ids = await self.get_invite_ids_with(target)
 				for gid in invite_ids:
@@ -272,6 +280,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
 		elif msg_type in ["typing", "stop_typing"]:
 			target = data.get("target")
+			logger.debug(f"[{msg_type}] user={self.username}({self.user_id}) → target={target}")
 			group = f"user_{target}" if target else self.group_name
 			await self.channel_layer.group_send(
 				group,

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -22,6 +22,7 @@ class ChessConsumer(AsyncWebsocketConsumer):
 		
 		#reject if this user is already in another game
 		if str(self.scope['user'].id) in IN_GAME_USERS:
+			logger.debug(f"[chess connect] rejected {self.scope['user']} — already in IN_GAME_USERS")
 			await self.close(code=4003)
 			return
 
@@ -67,6 +68,7 @@ class ChessConsumer(AsyncWebsocketConsumer):
 			# disappear everywhere — including invites from third parties.
 			for pid in player_ids:
 				for sender_id, gid in await self.get_pending_invites_for_recipient(pid):
+					logger.debug(f"[chess] expiring third-party invite game_id={gid} for player={pid} sender={sender_id}")
 					for uid in [pid, str(sender_id)]:
 						await self.channel_layer.group_send(
 							f'user_{uid}',

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -158,6 +158,21 @@ class ChessConsumer(AsyncWebsocketConsumer):
 		})
 
 		if over:
+			#read player names before deleting the game session
+			winner_color = over['winner']
+			if winner_color:
+				winner_name = getattr(self.game.players[winner_color], 'username', winner_color)
+				loser_color = 'black' if winner_color == 'white' else 'white'
+				loser_name = getattr(self.game.players[loser_color], 'username', None)
+				draw_players = None
+			else:
+				winner_name = None
+				loser_name = None
+				draw_players = [
+					getattr(self.game.players.get('white'), 'username', None),
+					getattr(self.game.players.get('black'), 'username', None),
+				]
+
 			#save result in db
 			await self.save_chess_result(self.game, over['winner'], over['result'])
 			for player in self.game.players.values():
@@ -172,22 +187,11 @@ class ChessConsumer(AsyncWebsocketConsumer):
 				'result': over['result']
 			})
 
-			#announce result to global chat
-			winner_color = over['winner']
-			if winner_color:
-				winner_name = getattr(self.game.players[winner_color], 'username', winner_color)
-				loser_color = 'black' if winner_color == 'white' else 'white'
-				loser_name = getattr(self.game.players[loser_color], 'username', None)
-			else:
-				winner_name = None
-				loser_name = None
-				white_name = getattr(self.game.players.get('white'), 'username', None)
-				black_name = getattr(self.game.players.get('black'), 'username', None)
 			await self.channel_layer.group_send('global_chat', {
 				'type': 'game_result',
 				'winner': winner_name,
 				'loser': loser_name,
-				'draw_players': [white_name, black_name] if not winner_name else None,
+				'draw_players': draw_players,
 				'game_type': 'chess',
 				'is_tournament': False
 			})

--- a/backend/chessgame/views.py
+++ b/backend/chessgame/views.py
@@ -45,6 +45,9 @@ def join_chess(request):
 	with ChessSession._lock:
 		if not invitee_id:
 			for game in ChessSession._games.values():
+				if game.status == 'waiting' and game.invitee_id is not None:
+					logger.debug(f"[join_chess] skipping invite-only session {game.id} for open matchmaking user={user}")
+					continue
 				if game.status == 'waiting' and game.invitee_id is None:
 					white_id = getattr(game.players['white'], 'id', None)
 					black_id = getattr(game.players['black'], 'id', None)

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -179,6 +179,7 @@ class GameConsumer(AsyncWebsocketConsumer):
 
         # Reject if user is already in another game
         if str(getattr(self.scope.get('user'), 'id', None)) in IN_GAME_USERS:
+            logger.debug(f"[pong connect] rejected {self.scope.get('user')} — already in IN_GAME_USERS")
             await self.close(code=4003)
             return
 
@@ -249,6 +250,7 @@ class GameConsumer(AsyncWebsocketConsumer):
             # Expire all pending invites for each player, including from third parties
             for pid in player_ids:
                 for sender_id, gid in await self.get_pending_invites_for_recipient(pid):
+                    logger.debug(f"[pong] expiring third-party invite game_id={gid} for player={pid} sender={sender_id}")
                     for uid in [pid, str(sender_id)]:
                         await self.channel_layer.group_send(
                             f'user_{uid}',

--- a/backend/game/views.py
+++ b/backend/game/views.py
@@ -113,6 +113,9 @@ def join_pong(request):
         return error
     with GameSession._lock:
         for game in GameSession._games.values():
+            if game.status == 'waiting' and not game.isTournamentGame and game.invitee_id is not None:
+                logger.debug(f"[join_pong] skipping invite-only session {game.id} for open matchmaking user={user}")
+                continue
             if game.status == 'waiting' and not game.isTournamentGame and game.invitee_id is None:
                 left_id = getattr(game.players['left'], 'id', None)
                 right_id = getattr(game.players['right'], 'id', None)


### PR DESCRIPTION
- Fix chess draw broadcast showing generic "A game of chess ended in a draw" without player names. Names were being read after the game session was deleted
- Add debug logging to all chat consumer events and invite-related backend code paths (chess/pong consumers and views)

Test plan:
Play a chess game to a draw.  Global chat should show both player names