### PR TITLE
feat(friends/block): enforce block rules on friendships

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -268,6 +268,14 @@ class ChatConsumer(AsyncWebsocketConsumer):
 						f'user_{target}',
 						{'type': 'game.invite.expired', 'game_id': gid}
 					)
+				await self.channel_layer.group_send(
+					f'user_{self.user_id}',
+					{'type': 'friend.list.changed'}
+				)
+				await self.channel_layer.group_send(
+					f'user_{target}',
+					{'type': 'friend.list.changed'}
+				)
 			await self.broadcast_online_users()
 
 		elif msg_type in ["typing", "stop_typing"]:
@@ -360,6 +368,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			"type": "game_invite_expired",
 			"game_id": game_id,
 		}))
+
+	async def friend_list_changed(self, _event):
+		await self.send(text_data=json.dumps({'type': 'friendListChanged'}))
 
 	async def typing_notification(self, event):
 		# Deliver a typing indicator to this consumer's client.

--- a/backend/friends/views.py
+++ b/backend/friends/views.py
@@ -188,6 +188,10 @@ def block_user(request):
 			return JsonResponse({'error': 'Cannot block yourself'}, status=400)
 		target = User.objects.get(id=target_id)
 		Block.objects.get_or_create(blocker=user, blocked_user=target)
+		FriendRequest.objects.filter(
+			Q(from_user=user, to_user=target) | Q(from_user=target, to_user=user),
+			status='accepted'
+		).delete()
 		return JsonResponse({'success': True, 'message': f'You have blocked {target.username}'})
 	except User.DoesNotExist:
 		return JsonResponse({'error': 'User does not exist'}, status=404)

--- a/backend/friends/views.py
+++ b/backend/friends/views.py
@@ -69,6 +69,9 @@ def send_friend_request(request):
 		to_user = get_recipient(request)
 		if from_user == to_user:
 			return JsonResponse({'error': 'Cannot make a friend request to yourself'}, status=400)
+		from .models import is_blocked
+		if is_blocked(from_user.id, to_user.id):
+			return JsonResponse({'error': 'Cannot send friend request'}, status=400)
 		if FriendRequest.objects.filter(
 			Q(from_user=from_user, to_user=to_user) | Q(from_user=to_user, to_user = from_user),
 			status='accepted').exists():

--- a/frontend/src/chat/chat.js
+++ b/frontend/src/chat/chat.js
@@ -158,6 +158,10 @@ export function initChat() {
 				}));
 				break;
 
+			case "friendListChanged":
+				window.dispatchEvent(new CustomEvent("friendListChanged"));
+				break;
+
 			case "game_result":
 				window.dispatchEvent(new CustomEvent("chatMessageReceived", {
 					detail: {

--- a/frontend/src/users_friends/profilePage.js
+++ b/frontend/src/users_friends/profilePage.js
@@ -56,6 +56,7 @@ function setupOwnProfile(){
     setupAddFriend();
     renderPendingRequests();
     renderFriendList();
+    window.addEventListener("friendListChanged", renderFriendList);
 }
 
 function hideOwnProfileSections(){


### PR DESCRIPTION
1. Prevented sending a friend request to a user you have blocked or who has blocked you.
Previously the block relationship was ignored at request-send time.

2. When a user blocks someone, any existing accepted friendship between them is now deleted immediately.
Previously friends remained in each other's list despite the block.

3. When user A blocks user B, the accepted FriendRequest between them is now deleted on the backend (previous commit).
However both users' profile pages previously required a manual refresh to reflect the change.
- backend/chat/consumers.py: added a friend.list.changed channel layer broadcast to both the blocker and the blocked user when a user_blocked WebSocket message is received.
Added a friend_list_changed handler method that forwarded the signal to the client as a friendListChanged WebSocket message
- frontend/src/chat/chat.js: added handling for the friendListChanged message by dispatching a window CustomEvent following the existing pattern.
- frontend/src/users_friends/profilePage.js: added a listener for that event in setupOwnProfile that calls renderFriendList(), so the list updates immediately without a page refresh.

Test plan

1. User A blocks user B, then tries to send B a friend request -> should be rejected with an error
2. User B (who is blocked by A) tries to send A a friend request -> should be rejected with an error
3. User A and B are friends. A blocks B -> the friendship should disappear from both users' friend lists immediately, without a page refresh


Note for Stan:

The friendListChanged window event listener added in setupOwnProfile in profilePage.js is never removed. When the user navigates away from the profile page, the listener stays attached to window and will fire on every subsequent block for the rest of the session. You should store the reference and call window.removeEventListener("friendListChanged", renderFriendList) on page teardown.

Note for Stan and Niko:
Additionally, two more cases still need real-time updates and require Niko's involvement on the backend:

1. When A sends B a friend request, B has to refresh to see it in pending. 
This would require Niko to push a new friend_request_received channel layer event to user_<B_id> from the send_friend_request REST view, and Stan to listen for it and call renderPendingRequests().

2. When B accepts A's request, A has to refresh to see B in their friends list. 
This would also require Niko to push friend_list_changed to user_<A_id> from the accept_request REST view. The friend_list_changed channel layer event and its WebSocket handler already exist - they were added in backend/chat/consumers.py in this PR, so the friendListChanged listener in profilePage.js is already in place for that case.