### PR TITLE
fix(game): allow players to leave a waiting game when accepting an invite

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -648,7 +648,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 			ConversationParticipant.objects.filter(
 				conversation_id=shared_conv_id,
 				user_id=user_id
-			).update(unread_count=0, last_read_at=timezone.now())
+			).update(unread_count=0, last_read_at=timezone.now(), is_closed=False)
 
 	@database_sync_to_async
 	def close_conversation(self, user_id, other_id):

--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -444,11 +444,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		)
 
 		# Only increment unread if the recipient doesn't currently have this conversation open.
-		# ACTIVE_CONVERSATION[recipient_id] == self.user_id means they are looking at our DM right now.
+		# ACTIVE_CONVERSATION[recipient_id] == sender_id means they are looking at our DM right now.
 		# F('unread_count') + 1 is a database-level increment — avoids race conditions
 		# if two messages arrive at the same time.
-		recipient_is_viewing = ACTIVE_CONVERSATION.get(recipient_id) == self.user_id
-		logger.info(f"[save_dm] sender={self.user_id} → recipient={recipient_id} | ACTIVE_CONVERSATION={dict(ACTIVE_CONVERSATION)} | recipient_is_viewing={recipient_is_viewing}")
+		sender_id = self.user_id
+		recipient_is_viewing = ACTIVE_CONVERSATION.get(recipient_id) == sender_id
+		logger.info(f"[save_dm] sender={sender_id} → recipient={recipient_id} | ACTIVE_CONVERSATION={dict(ACTIVE_CONVERSATION)} | recipient_is_viewing={recipient_is_viewing}")
 		if not recipient_is_viewing:
 			ConversationParticipant.objects.filter(
 				conversation=conversation,
@@ -558,7 +559,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
 		)
 		if not created:
 			return
-		recipient_is_viewing = ACTIVE_CONVERSATION.get(str(recipient_id)) == self.user_id
+		sender_id = self.user_id
+		recipient_is_viewing = ACTIVE_CONVERSATION.get(str(recipient_id)) == sender_id
 		if not recipient_is_viewing:
 			from chat.models import ConversationParticipant
 			ConversationParticipant.objects.filter(

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -27,7 +27,7 @@ class ChessConsumer(AsyncWebsocketConsumer):
 		if user_id_str in IN_GAME_USERS:
 			waiting_game = next(
 				(g for g in ChessSession._games.values()
-				 if g.status == 'waiting' and user_id_str in [str(getattr(p, 'id', None)) for p in g.players.values() if p]),
+				 if g.id != self.game_id and g.status == 'waiting' and user_id_str in [str(getattr(p, 'id', None)) for p in g.players.values() if p]),
 				None
 			)
 			if waiting_game:

--- a/backend/chessgame/consumers.py
+++ b/backend/chessgame/consumers.py
@@ -20,11 +20,24 @@ class ChessConsumer(AsyncWebsocketConsumer):
 			await self.close(code=4004)
 			return
 		
-		#reject if this user is already in another game
-		if str(self.scope['user'].id) in IN_GAME_USERS:
-			logger.debug(f"[chess connect] rejected {self.scope['user']} — already in IN_GAME_USERS")
-			await self.close(code=4003)
-			return
+		#reject if this user is already in an active game.
+		#if they are in a waiting game (e.g. matchmaking they just left to accept an invite),
+		#clean that up and allow this connection to proceed.
+		user_id_str = str(self.scope['user'].id)
+		if user_id_str in IN_GAME_USERS:
+			waiting_game = next(
+				(g for g in ChessSession._games.values()
+				 if g.status == 'waiting' and user_id_str in [str(getattr(p, 'id', None)) for p in g.players.values() if p]),
+				None
+			)
+			if waiting_game:
+				logger.debug(f"[chess connect] {self.scope['user']} leaving waiting game {waiting_game.id} to join invite game {self.game_id}")
+				IN_GAME_USERS.discard(user_id_str)
+				ChessSession.delete_game(waiting_game.id)
+			else:
+				logger.debug(f"[chess connect] rejected {self.scope['user']} — already in active IN_GAME_USERS")
+				await self.close(code=4003)
+				return
 
 		#try to seat this connection as white or black
 		self.color = self.game.add_player(self.scope['user'])

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -177,11 +177,24 @@ class GameConsumer(AsyncWebsocketConsumer):
         logger.debug(f"Headers: {headers}")
         logger.debug(f"Authorization: {headers.get(b'authorization')}")
 
-        # Reject if user is already in another game
-        if str(getattr(self.scope.get('user'), 'id', None)) in IN_GAME_USERS:
-            logger.debug(f"[pong connect] rejected {self.scope.get('user')} — already in IN_GAME_USERS")
-            await self.close(code=4003)
-            return
+        # Reject if user is already in an active game.
+        # If they are in a waiting game (e.g. matchmaking they just left to accept an invite),
+        # clean that up and allow this connection to proceed.
+        user_id_str = str(getattr(self.scope.get('user'), 'id', None))
+        if user_id_str in IN_GAME_USERS:
+            waiting_game = next(
+                (g for g in GameSession._games.values()
+                 if g.status == 'waiting' and user_id_str in [str(pid) for pid in g.players_ids.values() if pid]),
+                None
+            )
+            if waiting_game:
+                logger.debug(f"[pong connect] {self.scope.get('user')} leaving waiting game {waiting_game.id} to join invite game {self.game_id}")
+                IN_GAME_USERS.discard(user_id_str)
+                GameSession.delete_game(waiting_game.id)
+            else:
+                logger.debug(f"[pong connect] rejected {self.scope.get('user')} — already in active IN_GAME_USERS")
+                await self.close(code=4003)
+                return
 
         # Check for duplicate connections
         logger.debug(f"Scope: {self.scope}")

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -184,7 +184,7 @@ class GameConsumer(AsyncWebsocketConsumer):
         if user_id_str in IN_GAME_USERS:
             waiting_game = next(
                 (g for g in GameSession._games.values()
-                 if g.status == 'waiting' and user_id_str in [str(pid) for pid in g.players_ids.values() if pid]),
+                 if g.id != self.game_id and g.status == 'waiting' and user_id_str in [str(pid) for pid in g.players_ids.values() if pid]),
                 None
             )
             if waiting_game:

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -8,7 +8,6 @@ import { Engine, Scene } from "@babylonjs/core";
 import { initGameScene } from "../pong/game/game.js";
 import { checkAuthRequired, fetchWithRefreshAuth } from '../users_friends/usermanagement.js';
 import { updatePageTranslations, t, TranslationKey } from '../i18n/index.js';
-import { verifiedUserId } from '../chat/chat.js';
 import { createTournamentBtn, loadAllTournaments, startTournamentAutoRefresh, stopTournamentAutoRefresh, loadCompletedTournaments, loadOngoingTournaments,
   loadUpcomingTournaments
  } from '../pong/tournament/tournament_lobby_utils.js';


### PR DESCRIPTION
When B was in a matchmaking waiting room and then accepted an invite from A, B's new WebSocket connection to A's game could arrive at the server before the matchmaking disconnect had finished cleaning up IN_GAME_USERS. This race condition caused B to be rejected with 4003 and left without a game.

Instead of immediately rejecting any connection from a player already in IN_GAME_USERS, the connect handler now checks whether that player's current game is still in 'waiting' state. If it is, the waiting game is cleaned up and the new connection is allowed through. If the player is in an active game, the connection is still rejected as before.

Applied to both pong and chess consumers.
The lookup differs slightly: pong finds the waiting game by checking players_ids (a dict of user IDs), while chess checks players (a dict of user objects), matching each game's own model structure.