### PR TITLE
Rework UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ of the 42 curriculum by rverhoev, akaya-oz, tfeuer, nsarmada, snijhuis.
   - [Online Pong](#online-pong)
   - [AI Player](#ai-player)
   - [Tournaments](#tournaments)
-  - [Chess](#chess)
+  - [ ](#chess)
     - [Chess REST API](#chess-rest-api)
     - [Chess WebSocket Protocol](#chess-websocket-protocol)
   - [Friends](#friends)

--- a/frontend/public/routes/chess-online.html
+++ b/frontend/public/routes/chess-online.html
@@ -48,9 +48,11 @@
   </div>
 
   <!-- blocks the board until the other player arrives -->
-  <div id="waiting-overlay" class="absolute inset-0 z-20 flex flex-col items-center justify-center bg-gray-950/90">
-    <div class="mb-3 text-xl font-semibold text-white" data-i18n="CHESS_WAITING">Waiting for opponent...</div>
-    <div class="h-8 w-8 animate-spin rounded-full border-4 border-white border-t-transparent"></div>
+  <div id="waiting-overlay" class="absolute inset-0 z-20 flex items-center justify-center bg-zinc-900/90">
+    <div class="bg-zinc-800 rounded-lg p-8 flex flex-col items-center gap-4 text-center">
+      <p class="text-white text-xl font-semibold" data-i18n="CHESS_WAITING">Waiting for opponent...</p>
+      <div class="h-8 w-8 animate-spin rounded-full border-4 border-violet-400 border-t-transparent"></div>
+    </div>
   </div>
 
 </div>

--- a/frontend/public/routes/tournament-games.html
+++ b/frontend/public/routes/tournament-games.html
@@ -1,66 +1,62 @@
-<div id="menuOverlay" class="absolute inset-0 flex flex-col items-center justify-center bg-black/60 z-10 overflow-auto"
-  style="background-image: url('../assets/background.jpg'); background-size: cover; background-repeat: no-repeat;">
-  <div class="max-w-6xl w-full px-4 py-6">
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-white text-4xl font-bold" data-i18n="TOURNAMENT_GAMES_TITLE">Tournament Games</h1>
-      <button id="backBtn" class="px-6 py-3 bg-gray-600 hover:bg-gray-700 text-white rounded font-bold" data-i18n="STATS_BACK">
-        ← Back
-      </button>
-    </div>
+<div id="menuOverlay" class="min-h-screen bg-zinc-900 flex flex-col overflow-auto">
+    <div class="max-w-6xl w-full mx-auto px-4 py-6 flex flex-col gap-6">
 
-    <div id="tournamentTimerSection" class="bg-blue-900/50 border border-blue-500 rounded-lg p-4 mb-6 hidden">
-      <h2 class="text-white text-xl font-bold">Live Match Timer</h2>
-      <p class="text-blue-100 mt-1">Waiting rooms currently counting down:</p>
-      <div id="tournamentTimerList" class="mt-3 space-y-2"></div>
-    </div>
-    
-    <!-- Leaderboard -->
-    <div class="bg-gray-900/80 rounded-lg p-6 mb-6">
-      <h2 class="text-white text-2xl font-bold mb-4" data-i18n="TOURNAMENT_LEADERBOARD">Leaderboard</h2>
-      <table class="w-full text-white text-sm">
-        <thead class="border-b border-gray-700">
-          <tr>
-            <th class="text-left py-2" data-i18n="TOURNAMENT_TH_RANK">Rank</th>
-            <th class="text-left py-2" data-i18n="STATS_TH_PLAYER">Player</th>
-            <th class="text-right py-2" data-i18n="TOURNAMENT_TH_SCORE">Score</th>
-          </tr>
-        </thead>
-        <tbody id="leaderboardBody">
-          <tr><td colspan="3" class="text-gray-400 py-2" data-i18n="TOURNAMENT_LOADING_MSG">Loading...</td></tr>
-        </tbody>
-      </table>
-    </div>
+        <h1 class="text-white text-4xl font-bold text-center" data-i18n="TOURNAMENT_GAMES_TITLE">Tournament Games</h1>
 
-    <!-- Ready Games -->
-    <div class="bg-gray-900/80 rounded-lg p-6 mb-6">
-      <h2 class="text-white text-2xl font-bold mb-4" data-i18n="TOURNAMENT_READY_GAMES">Your Ready Games</h2>
-      <div id="readyGamesList" class="space-y-3">
-        <p class="text-gray-400" data-i18n="TOURNAMENT_LOADING_GAMES">Loading games...</p>
-      </div>
-    </div>
+        <div id="tournamentTimerSection" class="bg-zinc-800 rounded-lg p-6 hidden">
+            <h2 class="text-white text-2xl font-semibold mb-2">Live Match Timer</h2>
+            <p class="text-zinc-400 text-sm">Waiting rooms currently counting down:</p>
+            <div id="tournamentTimerList" class="mt-3 flex flex-col gap-2"></div>
+        </div>
 
-    <!-- Ongoing Games -->
-    <div class="bg-gray-900/80 rounded-lg p-6 mb-6">
-      <h2 class="text-white text-2xl font-bold mb-4" data-i18n="TOURNAMENT_ONGOING_GAMES">Ongoing Games</h2>
-      <div id="ongoingGamesList" class="space-y-3">
-        <p class="text-gray-400" data-i18n="TOURNAMENT_NO_ONGOING">No ongoing games</p>
-      </div>
-    </div>
+        <!-- Leaderboard -->
+        <div class="bg-zinc-800 rounded-lg p-6">
+            <h2 class="text-white text-2xl font-semibold mb-4" data-i18n="TOURNAMENT_LEADERBOARD">Leaderboard</h2>
+            <table class="w-full text-white text-sm">
+                <thead class="border-b border-zinc-700">
+                    <tr>
+                        <th class="text-left py-2" data-i18n="TOURNAMENT_TH_RANK">Rank</th>
+                        <th class="text-left py-2" data-i18n="STATS_TH_PLAYER">Player</th>
+                        <th class="text-right py-2" data-i18n="TOURNAMENT_TH_SCORE">Score</th>
+                    </tr>
+                </thead>
+                <tbody id="leaderboardBody">
+                    <tr><td colspan="3" class="text-zinc-400 py-2" data-i18n="TOURNAMENT_LOADING_MSG">Loading...</td></tr>
+                </tbody>
+            </table>
+        </div>
 
-    <!-- Future Round Games -->
-    <div class="bg-gray-900/80 rounded-lg p-6 mb-6">
-      <h2 class="text-white text-2xl font-bold mb-4">Future Round Games</h2>
-      <div id="futureGamesList" class="space-y-3">
-        <p class="text-gray-400">No future round games</p>
-      </div>
-    </div>
+        <!-- Ready Games -->
+        <div class="bg-zinc-800 rounded-lg p-6">
+            <h2 class="text-white text-2xl font-semibold mb-4" data-i18n="TOURNAMENT_READY_GAMES">Your Ready Games</h2>
+            <div id="readyGamesList" class="flex flex-col gap-3">
+                <p class="text-zinc-400" data-i18n="TOURNAMENT_LOADING_GAMES">Loading games...</p>
+            </div>
+        </div>
 
-    <!-- Completed Games -->
-    <div class="bg-gray-900/80 rounded-lg p-6">
-      <h2 class="text-white text-2xl font-bold mb-4" data-i18n="TOURNAMENT_COMPLETED_GAMES">Completed Games</h2>
-      <div id="completedGamesList" class="space-y-3">
-        <p class="text-gray-400" data-i18n="TOURNAMENT_NO_COMPLETED">No completed games</p>
-      </div>
+        <!-- Ongoing Games -->
+        <div class="bg-zinc-800 rounded-lg p-6">
+            <h2 class="text-white text-2xl font-semibold mb-4" data-i18n="TOURNAMENT_ONGOING_GAMES">Ongoing Games</h2>
+            <div id="ongoingGamesList" class="flex flex-col gap-3">
+                <p class="text-zinc-400" data-i18n="TOURNAMENT_NO_ONGOING">No ongoing games</p>
+            </div>
+        </div>
+
+        <!-- Future Round Games -->
+        <div class="bg-zinc-800 rounded-lg p-6">
+            <h2 class="text-white text-2xl font-semibold mb-4">Future Round Games</h2>
+            <div id="futureGamesList" class="flex flex-col gap-3">
+                <p class="text-zinc-400">No future round games</p>
+            </div>
+        </div>
+
+        <!-- Completed Games -->
+        <div class="bg-zinc-800 rounded-lg p-6">
+            <h2 class="text-white text-2xl font-semibold mb-4" data-i18n="TOURNAMENT_COMPLETED_GAMES">Completed Games</h2>
+            <div id="completedGamesList" class="flex flex-col gap-3">
+                <p class="text-zinc-400" data-i18n="TOURNAMENT_NO_COMPLETED">No completed games</p>
+            </div>
+        </div>
+
     </div>
-  </div>
 </div>

--- a/frontend/public/routes/tournament.html
+++ b/frontend/public/routes/tournament.html
@@ -1,91 +1,106 @@
-<div id="menuOverlay" class="absolute inset-0 flex flex-col items-center justify-center bg-black/60 z-10 overflow-auto"
-  style="background-image: url('../assets/background.jpg'); background-size: cover; background-repeat: no-repeat;">
-  <div class="max-w-6xl w-full px-4 py-6">
-    <h1 class="text-white text-4xl font-bold mb-6 text-center" data-i18n="TOURNAMENT_TITLE">Tournament Lobby</h1>
-    
-    <!-- Create Tournament Section -->
-    <div class="bg-gray-900/80 rounded-lg p-6 mb-6">
-      <h2 class="text-white text-2xl font-bold mb-4" data-i18n="TOURNAMENT_CREATE_NEW">Create New Tournament</h2>
-      <div class="flex flex-col gap-4">
-        <input 
-          type="text" 
-          id="tournamentName" 
-          data-i18n-placeholder="TOURNAMENT_NAME_PLACEHOLDER"
-          placeholder="Tournament Name" 
-          class="px-4 py-2 rounded bg-gray-800 text-white border border-gray-700 focus:border-blue-500 focus:outline-none"
-        />
-        <textarea 
-          id="tournamentDescription" 
-          data-i18n-placeholder="TOURNAMENT_DESC_PLACEHOLDER"
-          placeholder="Description (optional)" 
-          rows="2"
-          class="px-4 py-2 rounded bg-gray-800 text-white border border-gray-700 focus:border-blue-500 focus:outline-none"
-        ></textarea>
-        <div class="flex gap-4 items-center">
-          <label class="text-white" data-i18n="TOURNAMENT_MAX_PLAYERS">Max Players:</label>
-          <select id="tournamentMaxPlayers" class="px-4 py-2 rounded bg-gray-800 text-white border border-gray-700">
-            <option value="4">4</option>
-            <option value="8" selected>8</option>
-            <option value="16">16</option>
-            <option value="32">32</option>
-          </select>
-          <button id="createTournamentBtn" class="ml-auto px-6 py-2 bg-green-600 hover:bg-green-700 text-white rounded font-bold" data-i18n="TOURNAMENT_CREATE_BTN">
-            Create Tournament
-          </button>
-        </div>
-      </div>
-      <div id="createStatus" class="mt-3"></div>
-    </div>
+<div id="menuOverlay" class="min-h-screen bg-zinc-900 flex flex-col overflow-auto">
+    <div class="max-w-6xl w-full mx-auto px-4 py-6 flex flex-col gap-6">
 
-    <!-- Available Tournaments Section -->
-    <div class="bg-gray-900/80 rounded-lg p-6 mb-6">
-      <div class="flex justify-between items-center mb-4">
-        <h2 class="text-white text-2xl font-bold" data-i18n="TOURNAMENT_AVAILABLE">Available Tournaments</h2>
-        <button id="refreshTournamentsBtn" class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded" data-i18n="TOURNAMENT_REFRESH">
-          🔄 Refresh
-        </button>
-      </div>
-      <div id="tournamentsList" class="space-y-3 max-h-[30vh] overflow-y-scroll pr-2">
-        <p class="text-gray-400" data-i18n="TOURNAMENT_LOADING">Loading tournaments...</p>
-      </div>
-    </div>
+        <h1 class="text-white text-4xl font-bold text-center" data-i18n="TOURNAMENT_TITLE">Tournament Lobby</h1>
 
-    <!-- My Tournaments Section -->
-    <div class="bg-gray-900/80 rounded-lg p-6 mb-6 space-y-3 max-h-[30vh] overflow-y-scroll pr-2">
-      <h2 class="text-white text-2xl font-bold mb-4" data-i18n="TOURNAMENT_MY">My Tournaments</h2>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div>
-          <h3 class="text-blue-400 font-semibold mb-2" data-i18n="TOURNAMENT_ONGOING">Ongoing</h3>
-          <div id="ongoingTournaments" class="space-y-2">
-            <p class="text-gray-400 text-sm" data-i18n="TOURNAMENT_NONE">None</p>
-          </div>
+        <!-- Create Tournament Section -->
+        <div class="bg-zinc-800 rounded-lg p-6 flex flex-col gap-4">
+            <h2 class="text-white text-2xl font-semibold" data-i18n="TOURNAMENT_CREATE_NEW">Create New Tournament</h2>
+            <input id="tournamentName" type="text" data-i18n-placeholder="TOURNAMENT_NAME_PLACEHOLDER" placeholder="Tournament Name"
+                class="w-full p-2 rounded bg-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-violet-500">
+            <textarea id="tournamentDescription" rows="3" data-i18n-placeholder="TOURNAMENT_DESC_PLACEHOLDER" placeholder="Description (optional)"
+                class="w-full p-2 rounded bg-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-violet-500"></textarea>
+            <div class="flex gap-4 items-center">
+                <label class="text-zinc-300" data-i18n="TOURNAMENT_MAX_PLAYERS">Max Players:</label>
+                <select id="tournamentMaxPlayers"
+                    class="p-2 rounded bg-zinc-700 text-white focus:outline-none focus:ring-2 focus:ring-violet-500">
+                    <option value="4">4</option>
+                    <option value="8" selected>8</option>
+                    <option value="16">16</option>
+                    <option value="32">32</option>
+                </select>
+            </div>
+            <button id="createTournamentBtn"
+                class="w-full mt-2 bg-violet-600 hover:bg-violet-500 rounded-xl h-12 flex items-center justify-center font-semibold text-white text-base transition-colors duration-200 shadow-lg shadow-violet-500/20"
+                data-i18n="TOURNAMENT_CREATE_BTN">
+                Create Tournament
+            </button>
+            <div id="createStatus"></div>
         </div>
-        <div>
-          <h3 class="text-yellow-400 font-semibold mb-2" data-i18n="TOURNAMENT_UPCOMING">Upcoming</h3>
-          <div id="upcomingTournaments" class="space-y-2">
-            <p class="text-gray-400 text-sm" data-i18n="TOURNAMENT_NONE">None</p>
-          </div>
-        </div>
-        <div>
-          <h3 class="text-green-400 font-semibold mb-2" data-i18n="TOURNAMENT_COMPLETED">Completed</h3>
-          <div id="completedTournaments" class="space-y-2">
-            <p class="text-gray-400 text-sm" data-i18n="TOURNAMENT_NONE">None</p>
-          </div>
-        </div>
-      </div>
-      <!--- scroll bar-->
-        
-    </div>
 
-    <!-- Back Button -->
-    <div class="text-center">
-      <button id="backBtn" class="px-6 py-3 bg-gray-600 hover:bg-gray-700 text-white rounded font-bold" data-i18n="TOURNAMENT_BACK_TO_MENU">
-        ← Back to Menu
-      </button>
+        <!-- Available Tournaments Section -->
+        <div class="bg-zinc-800 rounded-lg p-6">
+            <div class="flex justify-between items-center mb-4">
+                <h2 class="text-white text-2xl font-semibold" data-i18n="TOURNAMENT_AVAILABLE">Available Tournaments</h2>
+                <button id="refreshTournamentsBtn"
+                    class="bg-violet-600 hover:bg-violet-500 rounded-xl px-4 h-10 flex items-center justify-center font-semibold text-white text-sm transition-colors duration-200 shadow-lg shadow-violet-500/20"
+                    data-i18n="TOURNAMENT_REFRESH">
+                    Refresh
+                </button>
+            </div>
+            <template id="tournament-card-template">
+                <div class="bg-zinc-700 rounded-lg p-4">
+                    <div class="flex justify-between items-start gap-4">
+                        <div class="flex-1">
+                            <h3 class="tournament-name text-white font-bold text-lg"></h3>
+                            <p class="tournament-description text-zinc-400 text-sm mt-1"></p>
+                            <div class="flex gap-4 mt-2 text-sm">
+                                <span class="tournament-players text-zinc-300"></span>
+                                <span class="tournament-creator text-zinc-300"></span>
+                                <span class="tournament-status text-yellow-400"></span>
+                            </div>
+                        </div>
+                        <div class="flex gap-2">
+                            <button class="join-btn bg-violet-600 hover:bg-violet-500 rounded-xl px-4 h-10 flex items-center justify-center font-semibold text-white text-sm transition-colors duration-200 shadow-lg shadow-violet-500/20" data-i18n="TOURNAMENT_JOIN">Join</button>
+                            <div class="joined-badge px-4 h-10 flex items-center justify-center text-violet-300 font-semibold text-sm" data-i18n="TOURNAMENT_JOINED">Joined</div>
+                            <button class="start-btn bg-violet-600 hover:bg-violet-500 rounded-xl px-4 h-10 flex items-center justify-center font-semibold text-white text-sm transition-colors duration-200 shadow-lg shadow-violet-500/20" data-i18n="TOURNAMENT_START">Start</button>
+                            <button class="cancel-btn px-4 h-10 rounded bg-zinc-600 text-white font-semibold text-sm hover:bg-red-500 transition" data-i18n="TOURNAMENT_CANCEL">Cancel</button>
+                            <span class="full-badge px-4 h-10 flex items-center justify-center text-zinc-400 text-sm" data-i18n="TOURNAMENT_FULL">Full</span>
+                        </div>
+                    </div>
+                </div>
+            </template>
+            <div id="tournamentsList" class="flex flex-col gap-3 max-h-[30vh] overflow-y-auto pr-2">
+                <p class="text-zinc-400" data-i18n="TOURNAMENT_LOADING">Loading tournaments...</p>
+            </div>
+        </div>
+
+        <!-- My Tournaments Section -->
+        <template id="my-tournament-card-template">
+            <div class="bg-zinc-700 rounded p-2 text-sm">
+                <div class="my-tournament-name text-white font-semibold"></div>
+                <div class="my-tournament-info text-zinc-400 text-xs"></div>
+                <button class="view-games-btn mt-2 w-full bg-violet-600 hover:bg-violet-500 rounded-xl h-9 flex items-center justify-center font-semibold text-white text-xs transition-colors duration-200 shadow-lg shadow-violet-500/20" data-i18n="TOURNAMENT_VIEW_GAMES">View Games</button>
+            </div>
+        </template>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="bg-zinc-800 rounded-lg p-6">
+                <p class="text-white font-semibold mb-3" data-i18n="TOURNAMENT_ONGOING">Ongoing</p>
+                <div id="ongoingTournaments" class="flex flex-col gap-2 max-h-[30vh] overflow-y-auto pr-2">
+                    <p class="text-zinc-400 text-sm" data-i18n="TOURNAMENT_NONE">None</p>
+                </div>
+            </div>
+            <div class="bg-zinc-800 rounded-lg p-6">
+                <p class="text-white font-semibold mb-3" data-i18n="TOURNAMENT_UPCOMING">Upcoming</p>
+                <div id="upcomingTournaments" class="flex flex-col gap-2 max-h-[30vh] overflow-y-auto pr-2">
+                    <p class="text-zinc-400 text-sm" data-i18n="TOURNAMENT_NONE">None</p>
+                </div>
+            </div>
+            <div class="bg-zinc-800 rounded-lg p-6">
+                <p class="text-white font-semibold mb-3" data-i18n="TOURNAMENT_COMPLETED">Completed</p>
+                <div id="completedTournaments" class="flex flex-col gap-2 max-h-[30vh] overflow-y-auto pr-2">
+                    <p class="text-zinc-400 text-sm" data-i18n="TOURNAMENT_NONE">None</p>
+                </div>
+            </div>
+        </div>
+
+        <div id="refreshGamesContainer" class="hidden">
+            <button id="refreshGamesBtn"
+                class="bg-violet-600 hover:bg-violet-500 rounded-xl px-4 h-10 flex items-center justify-center font-semibold text-white text-sm transition-colors duration-200 shadow-lg shadow-violet-500/20"
+                data-i18n="TOURNAMENT_REFRESH">
+                Refresh Games
+            </button>
+        </div>
+
     </div>
-  </div>
-  <div id="refreshGamesContainer" class="mt-3">
-    <button id="refreshGamesBtn" class="px-5 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded"
-      data-i18n="TOURNAMENT_REFRESH">Refresh Games</button>
-  </div>
 </div>

--- a/frontend/src/pong/game/game.js
+++ b/frontend/src/pong/game/game.js
@@ -173,11 +173,11 @@ export function joinOnlineGame(gameId, IsTournament) {
           <div id="scoreP2" class="font-mono font-bold text-6xl text-green-400 drop-shadow-lg" style="text-shadow: 0 0 10px rgba(74, 222, 128, 0.8);">0</div>
         </div>
       </div>
-      <div id="waitingModal" class="absolute inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50 pointer-events-auto">
-        <div class="bg-gray-900 border-2 border-green-400 rounded-lg p-8 text-center">
-          <h2 class="text-white text-2xl font-bold mb-4">${t('PONG_WAITING')}</h2>
-          <p class="text-gray-300 mb-2">${t('PONG_GAME_STARTING')}</p>
-          <button id="leaveWaitingBtn" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-6 rounded">
+      <div id="waitingModal" class="absolute inset-0 flex items-center justify-center z-50 bg-black/60 pointer-events-auto">
+        <div class="bg-zinc-800 rounded-lg p-8 w-full max-w-md mx-4 flex flex-col items-center gap-4 text-center">
+          <h2 class="text-white text-2xl font-bold" data-i18n="PONG_WAITING">${t('PONG_WAITING')}</h2>
+          <p class="text-zinc-400" data-i18n="PONG_GAME_STARTING">${t('PONG_GAME_STARTING')}</p>
+          <button id="leaveWaitingBtn" class="w-full mt-2 px-6 h-10 rounded bg-zinc-600 text-white font-semibold hover:bg-red-500 transition" data-i18n="PONG_LEAVE_GAME">
             ${t('PONG_LEAVE_GAME')}
           </button>
         </div>
@@ -212,13 +212,13 @@ export function joinOnlineGame(gameId, IsTournament) {
       }
 
       gameContainer.insertAdjacentHTML('beforeend', `
-        <div id="waitingModal" class="absolute inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50 pointer-events-auto">
-          <div class="bg-gray-900 border-2 border-green-400 rounded-lg p-8 text-center">
-            <h2 class="text-white text-2xl font-bold mb-4">Waiting for opponent...</h2>
-            <p class="text-gray-300 mb-2">Game will start soon</p>
-            <div class="text-4xl font-mono font-bold text-green-400 mb-6" id="countdownTimer"></div>
-            <p class="text-gray-400 text-sm mb-6">Game will proceed automatically when timer expires</p>
-            <button id="leaveWaitingBtn" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-6 rounded">
+        <div id="waitingModal" class="absolute inset-0 flex items-center justify-center z-50 bg-black/60 pointer-events-auto">
+          <div class="bg-zinc-800 rounded-lg p-8 w-full max-w-md mx-4 flex flex-col items-center gap-4 text-center">
+            <h2 class="text-white text-2xl font-bold" data-i18n="PONG_WAITING">Waiting for opponent...</h2>
+            <p class="text-zinc-400" data-i18n="PONG_GAME_STARTING">Game will start soon</p>
+            <div id="countdownTimer" class="text-4xl font-mono font-bold text-violet-400"></div>
+            <p class="text-zinc-400 text-sm">Game will proceed automatically when timer expires</p>
+            <button id="leaveWaitingBtn" class="w-full mt-2 px-6 h-10 rounded bg-zinc-600 text-white font-semibold hover:bg-red-500 transition" data-i18n="PONG_LEAVE_GAME">
               Leave Game
             </button>
           </div>

--- a/frontend/src/pong/tournament/tournament:ID_utils.js
+++ b/frontend/src/pong/tournament/tournament:ID_utils.js
@@ -85,7 +85,7 @@ function renderTournamentTimers() {
     const entries = Array.from(activeGameTimers.entries())
         .sort((a, b) => a[1] - b[1])
         .map(([id, timerData]) => `
-            <div class="bg-blue-950/50 border border-blue-700 rounded px-3 py-2 text-blue-100 text-sm">
+            <div class="bg-zinc-700 rounded px-3 py-2 text-zinc-200 text-sm">
                 Game: ${timerData.left_player} vs ${timerData.right_player}: <span class="font-bold text-white">${timerData.remaining}s</span> left to join
             </div>
         `)
@@ -107,17 +107,18 @@ async function loadLeaderBoard() {
     console.log("Tournament leaderboard:", leaderboardResult);
     if (leaderboardResult.ok && leaderboardResult.data) {
         const tbody = document.getElementById('leaderboardBody');
-        tbody.innerHTML = '';
+        const fragment = document.createDocumentFragment();
         leaderboardResult.data.forEach((participant, index) => {
         const row = document.createElement('tr');
-        row.className = 'border-b border-gray-700 hover:bg-gray-800';
+        row.className = 'border-b border-zinc-700 hover:bg-zinc-700';
         row.innerHTML = `
             <td class="py-2">${participant.rank || index + 1}</td>
             <td class="py-2">${participant.username}</td>
             <td class="text-right py-2">${participant.score}</td>
         `;
-        tbody.appendChild(row);
+        fragment.appendChild(row);
         });
+        tbody.replaceChildren(fragment);
     }
 
 }
@@ -128,25 +129,46 @@ async function loadReadyGames() {
     const readyResult = await tournamentAPI.getTournamentUserReadyGames(tournamentId);
     if (readyResult.ok && readyResult.data && readyResult.data.length > 0) {
         const listEl = document.getElementById('readyGamesList');
-        listEl.innerHTML = '';
+        const fragment = document.createDocumentFragment();
         let cnt = 0;
         readyResult.data.forEach(game => {
         console.log("Ready game:", game);
         const gameDiv = document.createElement('div');
-        gameDiv.className = 'bg-gray-800 rounded-lg p-4 border border-blue-500';
+        gameDiv.className = 'bg-zinc-700 rounded-lg p-4';
         if (cnt == 0)
         {
             gameDiv.innerHTML = `
             <div class="flex justify-between items-center">
             <div class="text-white">
             <div class="font-bold text-lg">${game.player1_username} vs ${game.player2_username}</div>
-                <div class="text-gray-400 text-sm">Round ${game.round}</div>
+                <div class="text-zinc-400 text-sm">Round ${game.round}</div>
                 </div>
-                <button class="start-game-btn px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded font-bold" data-game-id="${game.id}">
+                <button class="start-game-btn bg-violet-600 hover:bg-violet-500 rounded-xl px-6 h-10 lg:h-12 flex items-center justify-center font-semibold text-white text-sm lg:text-base transition-colors duration-200 shadow-lg shadow-violet-500/20" data-game-id="${game.id}">
                 Start Game
                 </button>
                 </div>
                 `;
+
+            const startBtn = gameDiv.querySelector('.start-game-btn');
+            startBtn.addEventListener('click', async () => {
+                if (await checkAuthRequired()) {
+                    showMessage(t('TOURN_LOGIN_REQUIRED'), 'error');
+                    return;
+                }
+                startBtn.disabled = true;
+                startBtn.textContent = 'Starting...';
+
+                const result = await tournamentAPI.startTournamentGame(game.id);
+                if (result.ok) {
+                    showMessage(t('TOURN_GAME_STARTED'), 'success');
+                    stopTournamentAutoRefresh();
+                    joinOnlineGame(result.data.game_id, true);
+                    return;
+                }
+                showMessage(result.data?.error || t('TOURN_GAME_START_FAILED'), 'error');
+                startBtn.disabled = false;
+                startBtn.textContent = 'Start Game';
+            });
         }
         else
         {
@@ -154,43 +176,18 @@ async function loadReadyGames() {
             <div class="flex justify-between items-center">
             <div class="text-white">
             <div class="font-bold text-lg">${game.player1_username} vs ${game.player2_username}</div>
-                <div class="text-gray-400 text-sm">Round ${game.round}</div>
+                <div class="text-zinc-400 text-sm">Round ${game.round}</div>
                 </div>
 
                 </div>
                 `;
         }
-        listEl.appendChild(gameDiv);
+        fragment.appendChild(gameDiv);
         cnt += 1;
         });
-        
-        // Add event listeners for starting games
-        listEl.querySelectorAll('.start-game-btn').forEach(btn => {
-        btn.addEventListener('click', async (e) => {
-            if (await checkAuthRequired()) {
-            showMessage(t('TOURN_LOGIN_REQUIRED'), 'error');
-            return;
-            }
-
-            const gameId = e.target.dataset.gameId;
-            btn.disabled = true;
-            btn.textContent = 'Starting...';
-
-            const result = await tournamentAPI.startTournamentGame(gameId);
-            if (result.ok) {
-            showMessage(t('TOURN_GAME_STARTED'), 'success');
-            // Redirect to the game
-            stopTournamentAutoRefresh();
-            joinOnlineGame(result.data.game_id, true);
-            } else {
-            showMessage(result.data?.error || t('TOURN_GAME_START_FAILED'), 'error');
-            btn.disabled = false;
-            btn.textContent = 'Start Game';
-            }
-        });
-        });
+        listEl.replaceChildren(fragment);
     } else {
-        document.getElementById('readyGamesList').innerHTML = '<p class="text-gray-400">No ready games for you.</p>';
+        document.getElementById('readyGamesList').innerHTML = '<p class="text-zinc-400">No ready games for you.</p>';
     }
 }
 
@@ -205,63 +202,66 @@ async function loadAllGamesStatus() {
         const ongoingList = document.getElementById('ongoingGamesList');
         const futureList = document.getElementById('futureGamesList');
         const completedList = document.getElementById('completedGamesList');
-        ongoingList.innerHTML = '';
-        futureList.innerHTML = '';
-        completedList.innerHTML = '';
-        
+
         const ongoingGames = allGamesResult.data.filter(g => g.status === 'ongoing');
         const futureGames = allGamesResult.data.filter(g => g.status === 'ready' || g.status === 'pending');
         const completedGames = allGamesResult.data.filter(g => g.status === 'completed');
-        
+
         if (ongoingGames.length === 0) {
-                ongoingList.innerHTML = `<p class="text-gray-400" data-i18n="TOURNAMENT_NO_ONGOING_GAMES">${t('TOURNAMENT_NO_ONGOING_GAMES')}</p>`;
+            ongoingList.innerHTML = `<p class="text-zinc-400" data-i18n="TOURNAMENT_NO_ONGOING_GAMES">${t('TOURNAMENT_NO_ONGOING_GAMES')}</p>`;
         } else {
-        ongoingGames.forEach(game => {
-            const gameDiv = document.createElement('div');
-            gameDiv.className = 'bg-gray-800 rounded-lg p-4 border border-yellow-500';
-            gameDiv.innerHTML = `
-            <div class="text-white">
-                <div class="font-bold">${game.player1_username} vs ${game.player2_username}</div>
-                <div class="text-gray-400 text-sm">${t('TOURNAMENT_ROUND')} ${game.round} - ${t('TOURNAMENT_ONGOING')}</div>
-            </div>
-            `;
-            ongoingList.appendChild(gameDiv);
-        });
+            const fragment = document.createDocumentFragment();
+            ongoingGames.forEach(game => {
+                const gameDiv = document.createElement('div');
+                gameDiv.className = 'bg-zinc-700 rounded-lg p-4';
+                gameDiv.innerHTML = `
+                <div class="text-white">
+                    <div class="font-bold">${game.player1_username} vs ${game.player2_username}</div>
+                    <div class="text-yellow-400 text-sm">${t('TOURNAMENT_ROUND')} ${game.round} - ${t('TOURNAMENT_ONGOING')}</div>
+                </div>
+                `;
+                fragment.appendChild(gameDiv);
+            });
+            ongoingList.replaceChildren(fragment);
         }
 
         if (futureGames.length === 0) {
-        futureList.innerHTML = '<p class="text-gray-400">No future round games</p>';
+            futureList.innerHTML = '<p class="text-zinc-400">No future round games</p>';
         } else {
-        futureGames
-            .sort((a, b) => Number(a.round || 0) - Number(b.round || 0))
-            .forEach(game => {
-            const gameDiv = document.createElement('div');
-            gameDiv.className = 'bg-gray-800 rounded-lg p-4 border border-indigo-500';
-            gameDiv.innerHTML = `
-            <div class="text-white">
-                <div class="font-bold">${game.player1_username} vs ${game.player2_username}</div>
-                <div class="text-indigo-300 text-sm">Round ${game.round} - ${game.status === 'ready' ? 'Scheduled' : 'Pending'}</div>
-            </div>
-            `;
-            futureList.appendChild(gameDiv);
-        });
+            const fragment = document.createDocumentFragment();
+            futureGames
+                .sort((a, b) => Number(a.round || 0) - Number(b.round || 0))
+                .forEach(game => {
+                const gameDiv = document.createElement('div');
+                gameDiv.className = 'bg-zinc-700 rounded-lg p-4';
+                gameDiv.innerHTML = `
+                <div class="text-white">
+                    <div class="font-bold">${game.player1_username} vs ${game.player2_username}</div>
+                    <div class="text-zinc-400 text-sm">Round ${game.round} - ${game.status === 'ready' ? 'Scheduled' : 'Pending'}</div>
+                </div>
+                `;
+                fragment.appendChild(gameDiv);
+            });
+            futureList.replaceChildren(fragment);
         }
-        
+
         if (completedGames.length === 0) {
-                completedList.innerHTML = `<p class="text-gray-400" data-i18n="TOURNAMENT_NO_COMPLETED_GAMES">${t('TOURNAMENT_NO_COMPLETED_GAMES')}</p>`;
+            completedList.innerHTML = `<p class="text-zinc-400" data-i18n="TOURNAMENT_NO_COMPLETED_GAMES">${t('TOURNAMENT_NO_COMPLETED_GAMES')}</p>`;
         } else {
-        completedGames.forEach(game => {
-            const gameDiv = document.createElement('div');
-            gameDiv.className = 'bg-gray-800 rounded-lg p-4 border border-green-500';
-            gameDiv.innerHTML = `
-            <div class="text-white">
-                <div class="font-bold">${game.player1_username} vs ${game.player2_username}</div>
-                        <div class="text-green-400 text-sm">🏆 ${t('TOURNAMENT_WINNER')}: ${game.winner_username ? game.winner_username : t('TOURNAMENT_NO_WINNER')}</div>
-                        <div class="text-gray-400 text-sm">${t('TOURNAMENT_ROUND')} ${game.round}</div>
-            </div>
-            `;
-            completedList.appendChild(gameDiv);
-        });
+            const fragment = document.createDocumentFragment();
+            completedGames.forEach(game => {
+                const gameDiv = document.createElement('div');
+                gameDiv.className = 'bg-zinc-700 rounded-lg p-4';
+                gameDiv.innerHTML = `
+                <div class="text-white">
+                    <div class="font-bold">${game.player1_username} vs ${game.player2_username}</div>
+                    <div class="text-green-400 text-sm">${t('TOURNAMENT_WINNER')}: ${game.winner_username ? game.winner_username : t('TOURNAMENT_NO_WINNER')}</div>
+                    <div class="text-zinc-400 text-sm">${t('TOURNAMENT_ROUND')} ${game.round}</div>
+                </div>
+                `;
+                fragment.appendChild(gameDiv);
+            });
+            completedList.replaceChildren(fragment);
         }
     }
 }

--- a/frontend/src/pong/tournament/tournament_lobby_utils.js
+++ b/frontend/src/pong/tournament/tournament_lobby_utils.js
@@ -1,6 +1,5 @@
-import { fetchWithRefreshAuth } from '../../users_friends/usermanagement.js';
 import * as tournamentAPI from './tournament_api.js';
-import { showMessage } from "../../utils/utils.js"
+import { showMessage } from "../../utils/utils.js";
 import { getCurrentUser } from '../../users_friends/usermanagement.js';
 import { navigate } from '../../routes/route_helpers.js';
 import { t } from '../../i18n/index.js';
@@ -8,25 +7,24 @@ import { stopTournamentUpdatesSocket } from './tournament_ws.js';
 
 let tournamentAutoRefreshInterval = null;
 
-function stopOnlyTournamentAutoRefreshInterval() {
-    if (tournamentAutoRefreshInterval) {
+function stopOnlyTournamentAutoRefreshInterval(){
+    if (tournamentAutoRefreshInterval){
         clearInterval(tournamentAutoRefreshInterval);
         tournamentAutoRefreshInterval = null;
     }
 }
 
-export function stopTournamentAutoRefresh() {
+export function stopTournamentAutoRefresh(){
     stopTournamentUpdatesSocket();
     stopOnlyTournamentAutoRefreshInterval();
 }
 
-export function startTournamentAutoRefresh(callback, intervalMs = 500) {
+export function startTournamentAutoRefresh(callback, intervalMs = 500){
     stopOnlyTournamentAutoRefreshInterval();
-  tournamentAutoRefreshInterval = setInterval(callback, intervalMs);
+    tournamentAutoRefreshInterval = setInterval(callback, intervalMs);
 }
 
-// Load all tournament lists
-export async function loadAllTournaments() {
+export async function loadAllTournaments(){
     await Promise.all([
         loadRegistrationTournaments(),
         loadOngoingTournaments(),
@@ -35,263 +33,216 @@ export async function loadAllTournaments() {
     ]);
 }
 
-// Load user's completed tournaments
-export async function loadCompletedTournaments() {
-    const result = await tournamentAPI.listCompletedTournaments();
-    const listEl = document.getElementById('completedTournaments');
-    if (!listEl) return;
-    
-    if (!result.ok || !result.data || result.data.length === 0) {
-    listEl.innerHTML = `<p class="text-gray-400 text-sm" data-i18n="TOURNAMENT_NONE">${t('TOURNAMENT_NONE')}</p>`;
-    return;
-    }
-    
-    const fragment = document.createDocumentFragment();
-    result.data.forEach(tournament => {
-    const div = document.createElement('div');
-    div.className = 'bg-gray-800 rounded p-2 text-sm';
-    div.innerHTML = `
-        <div class="text-white font-semibold">${tournament.name}</div>
-        <div class="text-gray-400 text-xs">👤 ${tournament.participant_count} ${t('TOURNAMENT_PLAYERS_PLACEHOLDER')}</div>
-        <button class="view-games-btn mt-2 px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded text-xs font-semibold w-full" data-tournament-id="${tournament.id}">
-        ${t('TOURNAMENT_VIEW_GAMES')}
-        </button>
-    `;
-    fragment.appendChild(div);
-    });
-    listEl.replaceChildren(fragment);
-    // Add event listeners
-    listEl.querySelectorAll('.view-games-btn').forEach(btn => {
-    btn.addEventListener('click', async (e) => {
-        const tournamentId = e.target.dataset.tournamentId;
-        console.log("Viewing tournament ID:", tournamentId);
-        navigate(`/tournament/${tournamentId}`);
-    });
-    });
-}
-
-// Load user's upcoming tournaments
-export async function loadUpcomingTournaments() {
-    const result = await tournamentAPI.listUpcomingTournaments();
-    const listEl = document.getElementById('upcomingTournaments');
-    if (!listEl) return;
-    
-    if (!result.ok || !result.data || result.data.length === 0) {
-    listEl.innerHTML = `<p class="text-gray-400 text-sm" data-i18n="TOURNAMENT_NONE">${t('TOURNAMENT_NONE')}</p>`;
-    return;
-    }
-    
-    const fragment = document.createDocumentFragment();
-    result.data.forEach(tournament => {
-    const div = document.createElement('div');
-    div.className = 'bg-gray-800 rounded p-2 text-sm';
-    div.innerHTML = `
-        <div class="text-white font-semibold">${tournament.name}</div>
-        <div class="text-gray-400 text-xs">👤 ${tournament.participant_count} ${t('TOURNAMENT_PLAYERS_PLACEHOLDER')}</div>
-    `;
-    fragment.appendChild(div);
-    });
-    listEl.replaceChildren(fragment);
-}
-
-// Load user's ongoing tournaments
-export async function loadOngoingTournaments() {
+export async function loadOngoingTournaments(){
     const result = await tournamentAPI.listOngoingTournaments();
-    const listEl = document.getElementById('ongoingTournaments');
-    if (!listEl) return;
-    
-    if (!result.ok || !result.data || result.data.length === 0) {
-    listEl.innerHTML = `<p class="text-gray-400 text-sm" data-i18n="TOURNAMENT_NONE">${t('TOURNAMENT_NONE')}</p>`;
-    return;
+    renderMyTournaments(result, "ongoingTournaments", true);
+}
+
+export async function loadUpcomingTournaments(){
+    const result = await tournamentAPI.listUpcomingTournaments();
+    renderMyTournaments(result, "upcomingTournaments", false);
+}
+
+export async function loadCompletedTournaments(){
+    const result = await tournamentAPI.listCompletedTournaments();
+    renderMyTournaments(result, "completedTournaments", true);
+}
+
+function renderMyTournaments(result, containerId, withViewButton){
+    const container = document.getElementById(containerId);
+    const template = document.getElementById("my-tournament-card-template");
+    if (!container) return;
+
+    if (!result.ok || !result.data || result.data.length === 0){
+        container.innerHTML = `<p class="text-zinc-400 text-sm" data-i18n="TOURNAMENT_NONE">${t('TOURNAMENT_NONE')}</p>`;
+        return;
     }
-    
+
     const fragment = document.createDocumentFragment();
     result.data.forEach(tournament => {
-    const div = document.createElement('div');
-    div.className = 'bg-gray-800 rounded p-2 text-sm';
-    div.innerHTML = `
-        <div class="text-white font-semibold">${tournament.name}</div>
-        <div class="text-gray-400 text-xs">👤 ${tournament.participant_count} players</div>
-        <button class="view-games-btn mt-2 px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded text-xs font-semibold w-full" data-tournament-id="${tournament.id}">
-        View Games
-        </button>
-    `;
-    fragment.appendChild(div);
+        const wrapDiv = document.createElement("div");
+        wrapDiv.innerHTML = template.innerHTML;
+        const card = wrapDiv.firstElementChild;
+
+        card.querySelector(".my-tournament-name").textContent = tournament.name;
+        card.querySelector(".my-tournament-info").textContent = `${tournament.participant_count} ${t('TOURNAMENT_PLAYERS_PLACEHOLDER')}`;
+
+        const viewBtn = card.querySelector(".view-games-btn");
+        if (withViewButton)
+            viewBtn.addEventListener("click", () => navigate(`/tournament/${tournament.id}`));
+        else
+            viewBtn.remove();
+
+        fragment.appendChild(card);
     });
-    listEl.replaceChildren(fragment);
-    
-    // Add event listeners
-    listEl.querySelectorAll('.view-games-btn').forEach(btn => {
-    btn.addEventListener('click', async (e) => {
-        const tournamentId = e.target.dataset.tournamentId;
-        console.log("Viewing tournament ID:", tournamentId);
-        navigate(`/tournament/${tournamentId}`);
-        });
-    });
+    container.replaceChildren(fragment);
 }
-    
-// Load tournaments open for registration
-async function loadRegistrationTournaments() {
+
+async function loadRegistrationTournaments(){
     const result = await tournamentAPI.listRegistrationTournaments();
-    const listEl = document.getElementById('tournamentsList');
-    if (!listEl) return;
-    
-    if (!result.ok || !result.data || result.data.length === 0) {
-    listEl.innerHTML = `<p class="text-gray-400" data-i18n="TOURNAMENT_NO_REGISTRATION">${t('TOURNAMENT_NO_REGISTRATION')}</p>`;
-    return;
+    const container = document.getElementById("tournamentsList");
+    const template = document.getElementById("tournament-card-template");
+    if (!container) return;
+
+    if (!result.ok || !result.data || result.data.length === 0){
+        container.innerHTML = `<p class="text-zinc-400" data-i18n="TOURNAMENT_NO_REGISTRATION">${t('TOURNAMENT_NO_REGISTRATION')}</p>`;
+        return;
     }
-    console.log("Registration tournaments:", result.data);
+
     const currentUser = await getCurrentUser();
     const currentUsername = currentUser?.username || localStorage.getItem('username');
+
     const fragment = document.createDocumentFragment();
+    result.data.forEach(tournament => {
+        const wrapDiv = document.createElement("div");
+        wrapDiv.innerHTML = template.innerHTML;
+        const card = wrapDiv.firstElementChild;
 
-    result.data.forEach((tournament) => {
-    const tournamentDiv = document.createElement('div');
-    tournamentDiv.className = 'bg-gray-800 rounded-lg p-4 border border-gray-700';
+        const isCreator = tournament.creator_username === currentUsername;
+        const isFull = tournament.participant_count >= tournament.max_players;
+        const isRegistered = (tournament.participants || []).some(p => p.username === currentUsername);
 
-    const isCreator = tournament.creator_username === currentUsername;
-    const isFull = tournament.participant_count >= tournament.max_players;
-    const isRegistered = (tournament.participants || []).some((p) => p.username === currentUsername);
-    console.log("isRegistered:", isRegistered);
+        fillTournamentCard(card, tournament);
+        wireTournamentCardButtons(card, tournament, isCreator, isFull, isRegistered);
 
-    tournamentDiv.innerHTML = `
-        <div class="flex justify-between items-start">
-        <div class="flex-1">
-            <h3 class="text-white font-bold text-lg">${tournament.name}</h3>
-            ${tournament.description ? `<p class="text-gray-400 text-sm mt-1">${tournament.description}</p>` : ''}
-            <div class="flex gap-4 mt-2 text-sm">
-            <span class="text-gray-300">👤 ${tournament.participant_count}/${tournament.max_players}</span>
-            <span class="text-gray-300">👑 ${tournament.creator_username}</span>
-            <span class="text-yellow-400">⏳ ${t('TOURNAMENT_STATUS_' + tournament.status.toUpperCase())}</span>
-            </div>
-        </div>
-        <div class="flex gap-2">
-            ${!isCreator && !isFull && !isRegistered ? `
-            <button class="join-btn px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm font-semibold" data-id="${tournament.id}">
-                ${t('TOURNAMENT_JOIN')}
-            </button>
-            ` : ''}
-            ${isRegistered && !isCreator ? `
-            <div class="px-4 py-2 bg-blue-500 text-white rounded text-sm font-semibold" data-id="${tournament.id}">
-                ${t('TOURNAMENT_JOINED')}
-            </div>
-            ` : ''}
-            ${isCreator ? `
-            <button class="start-btn px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded text-sm font-semibold" data-id="${tournament.id}">
-                ${t('TOURNAMENT_START')}
-            </button>
-            <button class="cancel-btn px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded text-sm font-semibold" data-id="${tournament.id}">
-                ${t('TOURNAMENT_CANCEL')}
-            </button>
-            ` : ''}
-            ${isFull && !isCreator ? `
-            <span class="px-4 py-2 bg-gray-600 text-gray-300 rounded text-sm">${t('TOURNAMENT_FULL')}</span>
-            ` : ''}
-        </div>
-        </div>
-    `;
-    
-    fragment.appendChild(tournamentDiv);
+        fragment.appendChild(card);
     });
-    listEl.replaceChildren(fragment);
-    
-    // Add event listeners for join/start/cancel buttons
-    listEl.querySelectorAll('.join-btn').forEach(btn => {
-    btn.addEventListener('click', async (e) => {
-        const tournamentId = e.target.dataset.id;
-        btn.disabled = true;
-        btn.textContent = t('TOURNAMENT_JOINING');
-        
-        const result = await tournamentAPI.joinTournament(tournamentId);
-        if (result.ok) {
-        showMessage(t('TOURN_JOINED'), 'success');
-        await loadAllTournaments();
-        } else {
-        showMessage(result.data?.error || t('TOURN_JOIN_FAILED'), 'error');
-        btn.disabled = false;
-        btn.textContent = t('TOURNAMENT_JOIN');
-        }
-    });
-    });
-    
-    listEl.querySelectorAll('.start-btn').forEach(btn => {
-    btn.addEventListener('click', async (e) => {
-        const tournamentId = e.target.dataset.id;
-        if (!confirm(t('TOURNAMENT_CONFIRM_START'))) return;
-        
-        btn.disabled = true;
-        btn.textContent = t('TOURNAMENT_STARTING');
-        
-        const result = await tournamentAPI.startTournament(tournamentId);
-        // result.ok = false; // TEMPORARY DISABLE STARTING TO PREVENT ISSUES WHILE TESTING
-        if (result.ok) {
-        showMessage(t('TOURN_STARTED'), 'success');
-        await loadAllTournaments();
-        } else {
-        showMessage(result.data?.error || t('TOURN_START_FAILED'), 'error');
-        btn.disabled = false;
-        btn.textContent = t('TOURNAMENT_START');
-        }
-    });
-    });
-    
-    listEl.querySelectorAll('.cancel-btn').forEach(btn => {
-    btn.addEventListener('click', async (e) => {
-        const tournamentId = e.target.dataset.id;
-        if (!confirm(t('TOURNAMENT_CONFIRM_CANCEL'))) return;
-        
-        btn.disabled = true;
-        btn.textContent = t('TOURNAMENT_CANCELLING');
-        
-        const result = await tournamentAPI.cancelTournament(tournamentId);
-        if (result.ok) {
-        showMessage(t('TOURN_CANCELLED'), 'success');
-        await loadAllTournaments();
-        } else {
-        showMessage(result.data?.error || t('TOURN_CANCEL_FAILED'), 'error');
-        btn.disabled = false;
-        btn.textContent = t('TOURNAMENT_CANCEL');
-        }
-    });
-    });
+    container.replaceChildren(fragment);
 }
 
-export async function createTournamentBtn()
-{
+function fillTournamentCard(card, tournament){
+    card.querySelector(".tournament-name").textContent = tournament.name;
+
+    const desc = card.querySelector(".tournament-description");
+    if (tournament.description)
+        desc.textContent = tournament.description;
+    else
+        desc.remove();
+
+    card.querySelector(".tournament-players").textContent = `${tournament.participant_count}/${tournament.max_players} ${t('TOURNAMENT_PLAYERS_PLACEHOLDER')}`;
+    card.querySelector(".tournament-creator").textContent = `by ${tournament.creator_username}`;
+    card.querySelector(".tournament-status").textContent = t('TOURNAMENT_STATUS_' + tournament.status.toUpperCase());
+}
+
+function wireTournamentCardButtons(card, tournament, isCreator, isFull, isRegistered){
+    const joinBtn = card.querySelector(".join-btn");
+    const joinedBadge = card.querySelector(".joined-badge");
+    const startBtn = card.querySelector(".start-btn");
+    const cancelBtn = card.querySelector(".cancel-btn");
+    const fullBadge = card.querySelector(".full-badge");
+
+    if (isCreator){
+        joinBtn.remove();
+        joinedBadge.remove();
+        fullBadge.remove();
+        startBtn.addEventListener("click", () => handleStart(tournament.id, startBtn));
+        cancelBtn.addEventListener("click", () => handleCancel(tournament.id, cancelBtn));
+        return;
+    }
+
+    startBtn.remove();
+    cancelBtn.remove();
+
+    if (isRegistered){
+        joinBtn.remove();
+        fullBadge.remove();
+        return;
+    }
+
+    joinedBadge.remove();
+
+    if (isFull){
+        joinBtn.remove();
+        return;
+    }
+
+    fullBadge.remove();
+    joinBtn.addEventListener("click", () => handleJoin(tournament.id, joinBtn));
+}
+
+async function handleJoin(tournamentId, btn){
+    btn.disabled = true;
+    btn.textContent = t('TOURNAMENT_JOINING');
+
+    const result = await tournamentAPI.joinTournament(tournamentId);
+    if (result.ok){
+        showMessage(t('TOURN_JOINED'), 'success');
+        await loadAllTournaments();
+        return;
+    }
+    showMessage(result.data?.error || t('TOURN_JOIN_FAILED'), 'error');
+    btn.disabled = false;
+    btn.textContent = t('TOURNAMENT_JOIN');
+}
+
+async function handleStart(tournamentId, btn){
+    if (!confirm(t('TOURNAMENT_CONFIRM_START')))
+        return;
+
+    btn.disabled = true;
+    btn.textContent = t('TOURNAMENT_STARTING');
+
+    const result = await tournamentAPI.startTournament(tournamentId);
+    if (result.ok){
+        showMessage(t('TOURN_STARTED'), 'success');
+        await loadAllTournaments();
+        return;
+    }
+    showMessage(result.data?.error || t('TOURN_START_FAILED'), 'error');
+    btn.disabled = false;
+    btn.textContent = t('TOURNAMENT_START');
+}
+
+async function handleCancel(tournamentId, btn){
+    if (!confirm(t('TOURNAMENT_CONFIRM_CANCEL')))
+        return;
+
+    btn.disabled = true;
+    btn.textContent = t('TOURNAMENT_CANCELLING');
+
+    const result = await tournamentAPI.cancelTournament(tournamentId);
+    if (result.ok){
+        showMessage(t('TOURN_CANCELLED'), 'success');
+        await loadAllTournaments();
+        return;
+    }
+    showMessage(result.data?.error || t('TOURN_CANCEL_FAILED'), 'error');
+    btn.disabled = false;
+    btn.textContent = t('TOURNAMENT_CANCEL');
+}
+
+export async function createTournamentBtn(){
     const name = document.getElementById('tournamentName').value.trim();
     const description = document.getElementById('tournamentDescription').value.trim();
     const maxPlayers = parseInt(document.getElementById('tournamentMaxPlayers').value);
-    
-    if (!name) {
+
+    if (!name){
         showStatus('createStatus', t('TOURN_NAME_REQUIRED'), 'error');
         return;
     }
-    
+
     showStatus('createStatus', t('TOURN_CREATING'), 'info');
     const result = await tournamentAPI.createTournament(name, description, maxPlayers);
-    
-    if (result.ok) {
+
+    if (result.ok){
         showStatus('createStatus', t('TOURN_CREATED'), 'success');
-        // Clear form
         document.getElementById('tournamentName').value = '';
         document.getElementById('tournamentDescription').value = '';
-        // Refresh lists
         setTimeout(() => loadAllTournaments(), 500);
-    } else {
-        showStatus('createStatus', result.data?.error || t('TOURN_CREATE_FAILED'), 'error');
+        return;
     }
+    showStatus('createStatus', result.data?.error || t('TOURN_CREATE_FAILED'), 'error');
 }
 
-// Helper function to show status messages
-function showStatus(elementId, message, type) {
+function showStatus(elementId, message, type){
     const statusEl = document.getElementById(elementId);
     if (!statusEl) return;
-    
+
     const colors = {
-    success: 'text-green-400',
-    error: 'text-red-400',
-    info: 'text-blue-400'
+        success: 'text-green-400',
+        error: 'text-red-400',
+        info: 'text-violet-400'
     };
-    
+
     statusEl.innerHTML = `<p class="${colors[type] || 'text-white'}">${message}</p>`;
 }

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -13,7 +13,7 @@ import { createTournamentBtn, loadAllTournaments, startTournamentAutoRefresh, st
  } from '../pong/tournament/tournament_lobby_utils.js';
 import { loadTournamentGames, handleTournamentSocketEvent, resetTournamentTimers } from '../pong/tournament/tournament:ID_utils.js';
 import { startTournamentUpdatesSocket } from '../pong/tournament/tournament_ws.js';
-import { showMessage } from "../utils/utils.js";
+import { showMessage, arrowHomeButton } from "../utils/utils.js";
 import { initChessGame } from '../chess/chess.js';
 import { initProfilePage } from "../users_friends/profilePage.js"
 import { initLoginPage } from "../users_friends/loginPage.js"
@@ -203,16 +203,14 @@ export function setupRoutes() {
 			return;
 
     await loadTemplate('tournament');
-    
+    arrowHomeButton();
+
     // Get current user for checking if they're tournament creato
     console.log("All cookies:", document.cookie);
-    
+
     // Load tournaments on page load
     await loadAllTournaments();
-    
-    // Back button
-    document.getElementById('backBtn')?.addEventListener('click', () => navigate('/pong'));
-    
+
     // Create tournament button
     document.getElementById('createTournamentBtn')?.addEventListener('click', async () => createTournamentBtn());
 
@@ -488,13 +486,12 @@ if (tbody) tbody.innerHTML = `<tr><td colspan="5" class="text-zinc-500" data-i18
 			return;
     
     await loadTemplate('tournament-games');
-    
+    arrowHomeButton();
+
     // Store tournament ID for use in callbacks
     window.currentTournamentId = tournamentId;
     resetTournamentTimers();
-    
-    document.getElementById('backBtn')?.addEventListener('click', () => navigate('/tournament'));
-    
+
     // Load tournament games and leaderboard
     await loadTournamentGames();
 


### PR DESCRIPTION
Restyle tournament + waiting screens to project palette.

- Tournament lobby and /tournament/:id restyled to zinc/violet, homepage button style
- Replaced in-page "Back to Menu" with floating top-left arrow (same as profile)
- Rewrote dynamic card rendering using template + querySelector pattern
- Restyled Pong waiting modal and chess waiting overlay to match
- Removed emojis from tournament UI
- DocumentFragment swap fixes the flicker on auto-refresh